### PR TITLE
Deleted empty readMe so the correct one shows up on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# pfcon
-
-This repo contains ``pfcon``, a coordinator / controller for ``pman`` and ``pfioh``.


### PR DESCRIPTION
The README.md file was essentially empty, and was being displayed in place of the README.rst which actually had a read me in it. It was very confusing. I deleted the readme.md in this pull request under the assumption that you were not using it. Now the correct readme displays,
@danmcp 