### PR TITLE
Self signed certs

### DIFF
--- a/pfcon/pfcon.py
+++ b/pfcon/pfcon.py
@@ -69,7 +69,7 @@ Gd_internalvar  = {
                 'addr':         '172.17.0.5:5055',
                 'baseURLpath':  'api/v1/cmd/',
                 'status':       'undefined',
-
+            
                 'storeAccess.tokenSet':  {
                     "action":   "internalctl",
                     "meta": {
@@ -124,9 +124,10 @@ Gd_internalvar  = {
         },
         'openshiftlocal': {
             'data': {
-                'addr':         'pfioh-myproject.127.0.0.1.nip.io',
+                'addr':         'https://pfioh-myproject.127.0.0.1.nip.io',
                 'baseURLpath':  'api/v1/cmd/',
                 'status':       'undefined',
+                'allowUnverifiedCertificates':      True,
 
                 'storeAccess.tokenSet':  {
                     "action":   "internalctl",
@@ -146,9 +147,10 @@ Gd_internalvar  = {
 
             },
             'compute': {
-                'addr':         'pman-myproject.127.0.0.1.nip.io',
+                'addr':         'https://pman-myproject.127.0.0.1.nip.io',
                 'baseURLpath':  'api/v1/cmd/',
-                'status':       'undefined'
+                'status':       'undefined',
+                'allowUnverifiedCertificates':      True
             }
         },
         'gondwanaland': {
@@ -185,6 +187,7 @@ Gd_internalvar  = {
                 'addr':         '10.17.24.163:5055',
                 'baseURLpath':  'api/v1/cmd/',
                 'status':       'undefined',
+                
 
                 'storeAccess.tokenSet':  {
                     "action":   "internalctl",
@@ -213,7 +216,7 @@ Gd_internalvar  = {
             'data': {
                 'addr':         'fnndsc.childrens.harvard.edu:5055',
                 'baseURLpath':  'api/v1/cmd/',
-                'status':       'undefined',
+                'status':       'undefined',                
 
                 'storeAccess.tokenSet':  {
                     "action":   "internalctl",
@@ -242,6 +245,7 @@ Gd_internalvar  = {
                 'addr':         '10.23.131.204:5055',
                 'baseURLpath':  'api/v1/cmd/',
                 'status':       'undefined',
+                
 
                 'storeAccess.tokenSet':  {
                     "action":   "internalctl",
@@ -269,7 +273,7 @@ Gd_internalvar  = {
             'data': {
                 'addr':         '%PFIOH_IP:5055',
                 'baseURLpath':  'api/v1/cmd/',
-                'status':       'undefined',
+                'status':       'undefined',                
 
                 'storeAccess.tokenSet':  {
                     "action":   "internalctl",
@@ -297,7 +301,7 @@ Gd_internalvar  = {
             'data': {
                 'addr':         '127.0.0.1:5055',
                 'baseURLpath':  'api/v1/cmd/',
-                'status':       'undefined',
+                'status':       'undefined',                
 
                 'storeAccess.tokenSet':  {
                     "action":   "internalctl",
@@ -319,6 +323,7 @@ Gd_internalvar  = {
                 'addr':         '127.0.0.1:5010',
                 'baseURLpath':  'api/v1/cmd/',
                 'status':       'undefined'
+                
             }
         }        
     }
@@ -532,6 +537,7 @@ class StoreHandler(BaseHTTPRequestHandler):
         str_remoteService       = d_meta['service']
         str_dataServiceAddr     = Gd_tree.cat('/service/%s/data/addr'       % str_remoteService)
         str_dataServiceURL      = Gd_tree.cat('/service/%s/data/baseURLpath'% str_remoteService)
+        unverifiedCerts = Gd_tree.cat('/service/%s/data/allowUnverifiedCertificates' % str_remoteService)
 
         dataComs = pfurl.Pfurl(
             msg                         = json.dumps(d_request),
@@ -540,7 +546,8 @@ class StoreHandler(BaseHTTPRequestHandler):
             b_quiet                     = False,
             b_raw                       = True,
             b_httpResponseBodyParse     = True,
-            jsonwrapper                 = ''
+            jsonwrapper                 = '',
+            b_unverifiedCerts           = unverifiedCerts
         )
 
         self.dp.qprint("Calling remote data service...",   comms = 'rx')
@@ -599,6 +606,7 @@ class StoreHandler(BaseHTTPRequestHandler):
         str_remoteService       = d_meta['service']
         str_computeServiceAddr  = Gd_tree.cat('/service/%s/compute/addr'        % str_remoteService)
         str_computeServiceURL   = Gd_tree.cat('/service/%s/compute/baseURLpath' % str_remoteService)
+        unverifiedCerts = Gd_tree.cat('/service/%s/data/allowUnverifiedCertificates' % str_remoteService)
 
         # Remember, 'pman' responses do NOT need to http-body parsed!
         computeComs = pfurl.Pfurl(
@@ -608,7 +616,8 @@ class StoreHandler(BaseHTTPRequestHandler):
             b_quiet                     = False,
             b_raw                       = True,
             b_httpResponseBodyParse     = False,
-            jsonwrapper                 = 'payload'
+            jsonwrapper                 = 'payload',
+            b_unverifiedCerts           = unverifiedCerts
         )
 
         self.dp.qprint("Calling remote compute service...", comms = 'rx')
@@ -835,6 +844,7 @@ class StoreHandler(BaseHTTPRequestHandler):
         str_remoteService       = d_meta['service']
         str_computeServiceAddr  = Gd_tree.cat('/service/%s/compute/addr'        % str_remoteService)
         str_computeServiceURL   = Gd_tree.cat('/service/%s/compute/baseURLpath' % str_remoteService)
+        unverifiedCerts = Gd_tree.cat('/service/%s/data/allowUnverifiedCertificates' % str_remoteService)
 
         d_remoteStatus  = {
             "action":   "status",
@@ -851,7 +861,8 @@ class StoreHandler(BaseHTTPRequestHandler):
             b_quiet                     = False,
             b_raw                       = True,
             b_httpResponseBodyParse     = False,
-            jsonwrapper                 = 'payload'
+            jsonwrapper                 = 'payload',
+            b_unverifiedCerts           = unverifiedCerts
         )
 
         self.dp.qprint("Calling remote compute service...", comms = 'rx')


### PR DESCRIPTION
@rudolphpienaar @danmcp 
- Requires the new verison of pfurl, and the previous pr to pfurl
- Can now communicate with pman/pfioh over https 
   - in order to do this all you have to do is change the address to start with https://
- Introduced a new field in the services tree, 'trusted':  [ True  |  False ]
   - setting this to true will allow pfcon to make insecure connections that accept self signed certificates
