### PR TITLE
bug fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN apt-get update \
   && echo "localuser:localuser" | chpasswd                            \
   && adduser localuser sudo                                           \
   && apt-get install -y libssl-dev libcurl4-openssl-dev bsdmainutils vim net-tools inetutils-ping \
+  && apt-get install python3-webob                                    \
+  && pip3 install ptvsd==3.0.0                                        \
+  && pip3 install pfmisc==1.0.1                                       \
+  && pip3 install webob                                               \
   && pip3 install /tmp/pfcon                                          \
   && rm -fr /tmp/pfcon                                                \
   && chmod 777 /dock                                                  \


### PR DESCRIPTION
# Changes
Setting up the data connection object in the service JSON object in the following format will allow you to send tokens to pfioh servers.
```
 'data': {
    'addr':            '%PFIOH_IP:5055',
    'baseURLpath':     'api/v1/cmd/',
    'status':          'undefined',
    "enableTokenAuth": True,
    "authTokens":      "password"
   },
```
All authToken fields should be in plain text
This can also send Tokens to pman, but it is not fully fleshed out yet. 
@danmcp @rudolphpienaar 