### PR TITLE
Correct setting for status return

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ###############
-pfcon  v2.0.2.0
+pfcon  v2.2.0.0
 ###############
 
 .. image:: https://badge.fury.io/py/pfcon.svg

--- a/bin/pfcon
+++ b/bin/pfcon
@@ -32,7 +32,7 @@ import  pudb
 from    pfmisc._colors             import Colors
 
 str_defIP = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
-str_version = "2.0.2.0"
+str_version = "2.2.0.0"
 str_desc = Colors.CYAN + """
 
         __                

--- a/cube_before_script.sh
+++ b/cube_before_script.sh
@@ -11,5 +11,5 @@ export STOREBASE=$(pwd)/FS/remote
 docker-compose up -d
 docker-compose exec chris_dev_db sh -c 'while ! mysqladmin -uroot -prootp status 2> /dev/null; do sleep 5; done;'
 docker-compose exec chris_dev_db mysql -uroot -prootp -e 'GRANT ALL PRIVILEGES ON *.* TO "chris"@"%"'
-docker-compose exec chris_dev python manage.py migrate
+# docker-compose exec chris_dev python manage.py migrate
 docker swarm init --advertise-addr 127.0.0.1

--- a/pfcon/pfcon.py
+++ b/pfcon/pfcon.py
@@ -712,7 +712,7 @@ class StoreHandler(BaseHTTPRequestHandler):
                             d_info[k]['return'] = {}
                             d_info[k]['status'] = ''
                         d_info[k]['status'] = str_status
-                        b_status            = str_status
+                        b_status            = True
                         if b_jobReturn:
                             d_info[k]['return'] = d_jobReturn
                         if b_jobSubmit:

--- a/pfcon/pfcon.py
+++ b/pfcon/pfcon.py
@@ -1906,9 +1906,11 @@ class StoreHandler(BaseHTTPRequestHandler):
         :return:
         """
         if not G_b_httpResponse:
-            self.wfile.write(json.dumps(d_ret).encode())
+            self.wfile.write(json.dumps(d_ret, indent = 4).encode())
         else:
-            self.wfile.write(str(Response(json.dumps(d_ret))).encode())
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(str(Response(json.dumps(d_ret, indent=4))).encode())
 
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 setup(
       name             =   'pfcon',
-      version          =   '2.0.2.0',
+      version          =   '2.2.0.0',
       description      =   '(Python) Process and File Controller',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
The b_status return must be bool, not string. This was an error in the original design. Fixed the spurious b_status assignment to the str_status.