### PR TITLE
Disable b_httpResponseBodyParse for pfurl to pfioh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ################
-pfcon  v2.2.6.4
+pfcon  v2.2.7.0
 ################
 
 .. image:: https://badge.fury.io/py/pfcon.svg

--- a/bin/pfcon
+++ b/bin/pfcon
@@ -22,7 +22,7 @@ import pudb
 from    pfmisc._colors             import Colors
 
 str_defIP = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
-str_version = "2.2.6.4"
+str_version = "2.2.7.0"
 str_desc = Colors.CYAN + """
 
         __

--- a/pfcon/pfcon.py
+++ b/pfcon/pfcon.py
@@ -429,19 +429,9 @@ class StoreHandler(BaseHTTPRequestHandler):
         )
         self.dp.qprint("Calling remote data service...",   comms = 'rx')
         # pudb.set_trace()
-        d_dataComs          = dataComs()
-        str_response        = d_dataComs.split('\n')
-        str_responseStatus  = str_response[0]
-        if len(str_response) > 1 and '200 OK' == str_responseStatus:
-            # Unusual case caused by pfurl returning a response string,
-            # during parsing of hello response, starting with "200 OK\n"
-            # Isolates json payload from request headers
-            d_dataComs = str_response[-1].replace('\\', '')
-            if d_dataComs[-1] == '\"':
-                d_dataComs = d_dataComs[:-1]
-
-        d_dataResponse                          = json.loads(d_dataComs)
-        d_ret['%s-data' % str_remoteService]    = d_dataResponse
+        d_dataComs = dataComs()
+        d_dataResponse = json.loads(d_dataComs)
+        d_ret['%s-data' % str_remoteService] = d_dataResponse
 
         d_return = {
             'd_ret':        d_ret,

--- a/pfcon/pfcon.py
+++ b/pfcon/pfcon.py
@@ -422,7 +422,7 @@ class StoreHandler(BaseHTTPRequestHandler):
             http                        = '%s/%s' % (str_dataServiceAddr, str_dataServiceURL),
             b_quiet                     = False,
             b_raw                       = True,
-            b_httpResponseBodyParse     = True,
+            b_httpResponseBodyParse     = False,
             jsonwrapper                 = '',
             authToken                   = str_token,
             httpProxy                   = Gd_tree.cat('/self/httpProxy/httpSpec')

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def readme():
 
 setup(
       name             =   'pfcon',
-      version          =   '2.2.6.4',
+      version          =   '2.2.7.0',
       description      =   '(Python) Process and File Controller',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
After https://github.com/FNNDSC/pfioh/pull/70 is merged, `b_httpResponseBodyParse` is obsolete.

`pfcon` should adhere to ordinary HTTP motifs where possible. 

This PR is optional, since `pfurl` silently goes with a fallback if `b_httpResponseBodyParse` is used where it shouldn't be. The intention of this PR is just to reduce code complexity.
