### PR TITLE
Add build for ppc64le

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@ __pycache__/
 
 .dockerignore
 Dockerfile
+prod.Dockerfile
 .travis.yml
 .gitignore
 .github
@@ -11,6 +12,6 @@ LICENSE
 CHRIS_REMOTE_FS
 swift_storage
 
-dist/
 .pixi/
+conda-specs/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,22 @@ jobs:
   build:
     needs: [test-pfcon, test-cube]
     runs-on: ubuntu-24.04
+    env:
+      PIXI_COLOR: always
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install micromamba
+      uses: mamba-org/setup-micromamba@v2
+      with:
+        cache-downloads: true
     - name: Install pixi
-      id: install-pixi
-      if: startsWith(github.ref, 'refs/tags/v')
       uses: prefix-dev/setup-pixi@v0.8.1
       with:
         pixi-version: v0.38.0
         run-install: false
     - name: Set version
-      if: steps.install-pixi.outcome == 'success'
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         ref_name='${{ github.ref_name }}'
         version_number="${ref_name:1}"
@@ -67,6 +72,23 @@ jobs:
           type=pep440,pattern={{version}}
           type=pep440,pattern={{major}}.{{minor}}
           type=raw,value=latest,enable={{is_default_branch}}
+
+      # pixi and micromamba don't have ppc64le images available, so to build
+      # images for ppc64le, we create conda environments using micromamba
+      # which are then copied into the container images. This also happens
+      # to be more efficient than running a package manager during docker
+      # build using QEMU.
+    - name: Export conda-explicit-spec
+      run: pixi project export conda-explicit-spec --frozen --ignore-pypi-errors conda-specs
+    - name: Create env for linux/amd64
+      run: micromamba create --platform linux-64      --relocate-prefix /opt/conda-env -f conda-specs/prod_linux-64_conda_spec.txt -p ./envs/linux/amd64
+    - name: Create env for linux/arm64
+      run: micromamba create --platform linux-aarch64 --relocate-prefix /opt/conda-env -f conda-specs/prod_linux-aarch64_conda_spec.txt -p ./envs/linux/arm64
+    - name: Create env for linux/ppc64le
+      run: micromamba create --platform linux-ppc64le --relocate-prefix /opt/conda-env -f conda-specs/prod_linux-ppc64le_conda_spec.txt -p ./envs/linux/ppc64le
+    - name: Build wheel
+      run: pixi run build
+
     - uses: docker/setup-qemu-action@v3
     - uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub
@@ -84,15 +106,13 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
-        build-args: ENVIRONMENT=prod
         push: ${{ steps.login-dockerhub.outcome == 'success' && steps.login-ghcr.outcome == 'success' }}
         context: .
-        file: ./Dockerfile
-        platforms: linux/amd64,linux/arm64
+        file: ./prod.Dockerfile
+        platforms: linux/amd64,linux/arm64,linux/ppc64le
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ swift_storage/
 # pixi environments
 .pixi
 *.egg-info
+
+# build
+conda-specs/
+envs/
+

--- a/pixi.lock
+++ b/pixi.lock
@@ -79,6 +79,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.4-pyhd8ed1ab_0.conda
@@ -162,6 +163,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.4-pyhd8ed1ab_0.conda
@@ -172,6 +174,89 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.23.0-py312h9fc3309_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+      - pypi: .
+      linux-ppc64le:
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aniso8601-9.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-python-1.1.0-py313h3c9ed74_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h1f2b957_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2024.12.14-h0f6029e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/cffi-1.17.1-py313h82f3f0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/debtcollector-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/environs-9.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-restful-0.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iso8601-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/keystoneauth1-4.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.43-h5c2c55b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libexpat-2.6.4-h2621725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-14.2.0-h31e42bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-14.2.0-hfdc3801_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-14.2.0-h31e42bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/liblzma-5.6.3-h190368a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libmpdec-4.0.0-h1f2b957_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.47.2-haeeb200_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-14.2.0-h262982c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-ng-14.2.0-hf27a640_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.38.1-h4194056_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.3.1-h190368a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/markupsafe-3.0.2-py313h1d1471b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-3.23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/msgpack-python-1.1.0-py313ha5143e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.5-hd444e8b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/netaddr-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.4.0-h190368a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/os-service-types-1.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.config-9.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.i18n-6.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.serialization-5.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.utils-8.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/psutil-6.1.0-py313h7aac8da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/python-3.13.1-hecb7ae0_102_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-keystoneclient-4.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-swiftclient-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/python_abi-3.13-5_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/pyyaml-6.0.2-py313h7aac8da_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.2-h0b9b154_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.13-hd4bbf49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/wrapt-1.17.0-py313h7aac8da_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/yaml-0.2.5-h4e0d66e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstandard-0.23.0-py313h75d07f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstd-1.5.6-h03a2076_0.conda
       - pypi: .
   local:
     channels:
@@ -446,6 +531,139 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.23.0-py312h9fc3309_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
       - pypi: .
+      linux-ppc64le:
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aniso8601-9.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-python-1.1.0-py312h239da9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h1f2b957_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2024.12.14-h0f6029e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/cffi-1.17.1-py312hf7fc64c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/cryptography-44.0.0-py312hc1c30b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/dbus-1.13.6-h0f95b14_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/debtcollector-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/environs-9.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/expat-2.6.4-h2621725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-restful-0.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.27.0-pypyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iso8601-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.5.0-pyha804496_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/keystoneauth1-4.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.43-h5c2c55b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libexpat-2.6.4-h2621725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-14.2.0-h31e42bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-14.2.0-hfdc3801_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libglib-2.82.2-h3d6172d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-14.2.0-h31e42bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libiconv-1.17-ha17a0cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/liblzma-5.6.3-h190368a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libnsl-2.0.1-ha17a0cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.47.2-haeeb200_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-14.2.0-h262982c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-ng-14.2.0-hf27a640_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.38.1-h4194056_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libxcrypt-4.4.36-ha17a0cc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.3.1-h190368a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/markupsafe-3.0.2-py312h1d80cea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-3.23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/msgpack-python-1.1.0-py312hc0892ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.5-hd444e8b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/netaddr-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.4.0-h190368a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/os-service-types-1.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.config-9.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.i18n-6.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.serialization-5.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.utils-8.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/pcre2-10.44-h3dd95db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/psutil-6.1.0-py312h2984477_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/python-3.12.8-he016669_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-keystoneclient-4.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-swiftclient-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/pyyaml-6.0.2-py312h2984477_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.2-h0b9b154_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/secretstorage-3.3.3-py312h2344ed7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.13-hd4bbf49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.7.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/uv-0.5.11-h3ec8af1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/wrapt-1.17.0-py312h2984477_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/yaml-0.2.5-h4e0d66e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstandard-0.23.0-py312h3e12cc9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstd-1.5.6-h03a2076_0.conda
+      - pypi: .
   prod:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -526,6 +744,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.4-pyhd8ed1ab_0.conda
@@ -610,6 +829,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.0.4-pyhd8ed1ab_0.conda
@@ -620,6 +840,92 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.20.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.23.0-py312h9fc3309_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+      - pypi: .
+      linux-ppc64le:
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aniso8601-9.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-python-1.1.0-py312h239da9a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h1f2b957_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2024.12.14-h0f6029e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/cffi-1.17.1-py312hf7fc64c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/debtcollector-3.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/environs-9.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-2.3.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flask-restful-0.3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/gunicorn-21.2.0-py312h7864ebf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iso8601-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/keystoneauth1-4.3.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.43-h5c2c55b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libexpat-2.6.4-h2621725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-14.2.0-h31e42bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-14.2.0-hfdc3801_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-14.2.0-h31e42bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/liblzma-5.6.3-h190368a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libnsl-2.0.1-ha17a0cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.47.2-haeeb200_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-14.2.0-h262982c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-ng-14.2.0-hf27a640_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.38.1-h4194056_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libxcrypt-4.4.36-ha17a0cc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.3.1-h190368a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/markupsafe-3.0.2-py312h1d80cea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/marshmallow-3.23.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/msgpack-python-1.1.0-py312hc0892ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.5-hd444e8b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/netaddr-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.4.0-h190368a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/os-service-types-1.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.config-9.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.i18n-6.5.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.serialization-5.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oslo.utils-8.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/psutil-6.1.0-py312h2984477_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/python-3.12.8-he016669_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-keystoneclient-4.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-swiftclient-4.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/pyyaml-6.0.2-py312h2984477_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.2-h0b9b154_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.13-hd4bbf49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/wrapt-1.17.0-py312h2984477_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/yaml-0.2.5-h4e0d66e_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstandard-0.23.0-py312h3e12cc9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstd-1.5.6-h03a2076_0.conda
       - pypi: .
 packages:
 - kind: conda
@@ -634,6 +940,18 @@ packages:
   purls: []
   size: 2562
   timestamp: 1578324546067
+- kind: conda
+  name: _libgcc_mutex
+  version: '0.1'
+  build: conda_forge
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2
+  sha256: 5dd34b412e6274c0614d01a2f616844376ae873dfb8782c2c67d055779de6df6
+  md5: e96f48755dc7c9f86c4aecf4cac40477
+  license: None
+  purls: []
+  size: 2550
+  timestamp: 1578324511581
 - kind: conda
   name: _openmp_mutex
   version: '4.5'
@@ -672,6 +990,25 @@ packages:
   size: 23712
   timestamp: 1650670790230
 - kind: conda
+  name: _openmp_mutex
+  version: '4.5'
+  build: 2_gnu
+  build_number: 16
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2
+  sha256: 4c89c2067cf5e7b0fbbdc3200c3f7affa5896e14812acf10f51575be87ae0c05
+  md5: 3e41cbaba7e4988d15a24c4e85e6171b
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl 9999
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 23710
+  timestamp: 1650671119831
+- kind: conda
   name: aniso8601
   version: 9.0.1
   build: pyhd8ed1ab_0
@@ -689,6 +1026,25 @@ packages:
   - pkg:pypi/aniso8601?source=hash-mapping
   size: 38716
   timestamp: 1618789622646
+- kind: conda
+  name: aniso8601
+  version: 9.0.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/aniso8601-9.0.1-pyhd8ed1ab_1.conda
+  sha256: e2a09c5909cbdb3262fc7b750b9d126b1e0fd0e724d342302e222b57ec145d7e
+  md5: 55626ecdf6f0fc2982388daf470da31d
+  depends:
+  - python >=3.9
+  - python-dateutil
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/aniso8601?source=hash-mapping
+  size: 42023
+  timestamp: 1734243042596
 - kind: conda
   name: anyio
   version: 4.4.0
@@ -714,6 +1070,30 @@ packages:
   size: 104255
   timestamp: 1717693144467
 - kind: conda
+  name: anyio
+  version: 4.7.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.7.0-pyhd8ed1ab_0.conda
+  sha256: 687537ee3af30f8784986bf40cac30e88138770b16e51ca9850c9c23c09aeba1
+  md5: c88107912954a983c2caf25f7fd55158
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.5
+  constrains:
+  - trio >=0.26.1
+  - uvloop >=0.21
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/anyio?source=hash-mapping
+  size: 112730
+  timestamp: 1733532678437
+- kind: conda
   name: backports
   version: '1.0'
   build: pyhd8ed1ab_4
@@ -730,6 +1110,23 @@ packages:
   purls: []
   size: 6989
   timestamp: 1722295637981
+- kind: conda
+  name: backports
+  version: '1.0'
+  build: pyhd8ed1ab_5
+  build_number: 5
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
+  sha256: e1c3dc8b5aa6e12145423fed262b4754d70fec601339896b9ccf483178f690a6
+  md5: 767d508c1a67e02ae8f50e44cacfadb2
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 7069
+  timestamp: 1733218168786
 - kind: conda
   name: backports.tarfile
   version: 1.0.0
@@ -750,6 +1147,25 @@ packages:
   size: 31951
   timestamp: 1712700751335
 - kind: conda
+  name: backports.tarfile
+  version: 1.2.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
+  sha256: a0f41db6d7580cec3c850e5d1b82cb03197dd49a3179b1cee59c62cd2c761b36
+  md5: df837d654933488220b454c6a3b0fad6
+  depends:
+  - backports
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/backports-tarfile?source=hash-mapping
+  size: 32786
+  timestamp: 1733325872620
+- kind: conda
   name: blinker
   version: 1.8.2
   build: pyhd8ed1ab_0
@@ -766,6 +1182,46 @@ packages:
   - pkg:pypi/blinker?source=hash-mapping
   size: 14707
   timestamp: 1715091300511
+- kind: conda
+  name: blinker
+  version: 1.9.0
+  build: pyhff2d567_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+  sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
+  md5: 42834439227a4551b939beeeb8a4b085
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/blinker?source=hash-mapping
+  size: 13934
+  timestamp: 1731096548765
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py312h239da9a_2
+  build_number: 2
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-python-1.1.0-py312h239da9a_2.conda
+  sha256: 616471faed82e452e9b3d42879870591c121f9427f934f29e594c40561a264dc
+  md5: d1ab405070c0c4483cf1b58adae4eb15
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - libbrotlicommon 1.1.0 h190368a_2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
+  size: 392023
+  timestamp: 1725267889535
 - kind: conda
   name: brotli-python
   version: 1.1.0
@@ -811,6 +1267,45 @@ packages:
   - pkg:pypi/brotli?source=hash-mapping
   size: 350604
   timestamp: 1695990206327
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py313h3c9ed74_2
+  build_number: 2
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-python-1.1.0-py313h3c9ed74_2.conda
+  sha256: e5969d65f39ccb2376f645754671f4233e0a99c55c4ccc16451aae3efab229cf
+  md5: fa4a805ac24344e254b6c8b51d8ba39f
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.13.0rc1,<3.14.0a0
+  - python >=3.13.0rc1,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - libbrotlicommon 1.1.0 h190368a_2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/brotli?source=hash-mapping
+  size: 391948
+  timestamp: 1725267952817
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h1f2b957_7
+  build_number: 7
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h1f2b957_7.conda
+  sha256: 9ab9e6ac16be381f6636309084f3a1fadf50b4d7e9d6e145d53160de65b7987a
+  md5: 28bea4cad2ab5d1ce9e3be6ab7fadac4
+  depends:
+  - libgcc-ng >=12
+  license: bzip2-1.0.6
+  license_family: BSD
+  purls: []
+  size: 198975
+  timestamp: 1720974494530
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -869,6 +1364,18 @@ packages:
   size: 154904
   timestamp: 1720078197019
 - kind: conda
+  name: ca-certificates
+  version: 2024.12.14
+  build: h0f6029e_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2024.12.14-h0f6029e_0.conda
+  sha256: b969da124c415582e913b7121ba10f5e3d64ca7fafc66f67eef373dfb68883b9
+  md5: 70f872c20d0d5898ecd7a977940b1c15
+  license: ISC
+  purls: []
+  size: 157101
+  timestamp: 1734209014702
+- kind: conda
   name: certifi
   version: 2024.7.4
   build: pyhd8ed1ab_0
@@ -884,6 +1391,22 @@ packages:
   - pkg:pypi/certifi?source=hash-mapping
   size: 159308
   timestamp: 1720458053074
+- kind: conda
+  name: certifi
+  version: 2024.12.14
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/certifi-2024.12.14-pyhd8ed1ab_0.conda
+  sha256: 048c16a9cbcb1fbad02083414d3bc7c1d0eea4b39aee6aa6bf8d1d5089ca8bad
+  md5: 6feb87357ecd66733be3279f16a8c400
+  depends:
+  - python >=3.9
+  license: ISC
+  purls:
+  - pkg:pypi/certifi?source=hash-mapping
+  size: 161642
+  timestamp: 1734380604767
 - kind: conda
   name: cffi
   version: 1.17.0
@@ -926,6 +1449,46 @@ packages:
   size: 312338
   timestamp: 1723019714184
 - kind: conda
+  name: cffi
+  version: 1.17.1
+  build: py312hf7fc64c_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/cffi-1.17.1-py312hf7fc64c_0.conda
+  sha256: c8774152bcf432cfba24f15c8286082b580660281042696498ce601bc5fd2f65
+  md5: 866041d4834d8aab50b962e6c3145603
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 305369
+  timestamp: 1725561519234
+- kind: conda
+  name: cffi
+  version: 1.17.1
+  build: py313h82f3f0c_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/cffi-1.17.1-py313h82f3f0c_0.conda
+  sha256: 9b02a18dba2a0fab2e1fb0eaa9fd476934ebc13d917f41febd99a6a00243d0d2
+  md5: 7971e3154958694febfa8c6413716c3c
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - pycparser
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 307432
+  timestamp: 1725561891307
+- kind: conda
   name: charset-normalizer
   version: 3.3.2
   build: pyhd8ed1ab_0
@@ -942,6 +1505,24 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 46597
   timestamp: 1698833765762
+- kind: conda
+  name: charset-normalizer
+  version: 3.4.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_1.conda
+  sha256: 63022ee2c6a157a9f980250a66f54bdcdf5abee817348d0f9a74c2441a6fbf0e
+  md5: 6581a17bba6b948bb60130026404a9d6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=hash-mapping
+  size: 47533
+  timestamp: 1733218182393
 - kind: conda
   name: click
   version: 8.1.7
@@ -961,6 +1542,25 @@ packages:
   size: 84437
   timestamp: 1692311973840
 - kind: conda
+  name: click
+  version: 8.1.7
+  build: unix_pyh707e725_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_1.conda
+  sha256: 1cd5fc6ccdd5141378e51252a7a3810b07fd5a7e6934a5b4a7eccba66566224b
+  md5: cb8e52f28f5e592598190c562e7b5bf1
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/click?source=hash-mapping
+  size: 84513
+  timestamp: 1733221925078
+- kind: conda
   name: colorama
   version: 0.4.6
   build: pyhd8ed1ab_0
@@ -977,6 +1577,24 @@ packages:
   - pkg:pypi/colorama?source=hash-mapping
   size: 25170
   timestamp: 1666700778190
+- kind: conda
+  name: colorama
+  version: 0.4.6
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
+  size: 27011
+  timestamp: 1733218222191
 - kind: conda
   name: cryptography
   version: 43.0.0
@@ -1023,6 +1641,47 @@ packages:
   - pkg:pypi/cryptography?source=hash-mapping
   size: 1506173
   timestamp: 1721521528415
+- kind: conda
+  name: cryptography
+  version: 44.0.0
+  build: py312hc1c30b0_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/cryptography-44.0.0-py312hc1c30b0_0.conda
+  sha256: a1cd92ac5a3caecc72326d4a153331a1fcaaa235dd99069a06122381544c9b58
+  md5: 324dfe0c2ff941ae5e556248de4163d2
+  depends:
+  - cffi >=1.12
+  - libgcc >=13
+  - openssl >=3.4.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  size: 1606665
+  timestamp: 1732746291530
+- kind: conda
+  name: dbus
+  version: 1.13.6
+  build: h0f95b14_3
+  build_number: 3
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/dbus-1.13.6-h0f95b14_3.tar.bz2
+  sha256: 722e8972a9f461064e45603b9194fc17e1b2e1cf23a73b0fca16cd5231c32261
+  md5: 061b5b6712526e334f0fd45ef1379b4b
+  depends:
+  - expat >=2.4.2,<3.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.2,<3.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 750518
+  timestamp: 1640113798164
 - kind: conda
   name: dbus
   version: 1.13.6
@@ -1078,6 +1737,25 @@ packages:
   size: 22491
   timestamp: 1708788175713
 - kind: conda
+  name: debtcollector
+  version: 3.0.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/debtcollector-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 88cfc741c905ee4deb8973294a465f1b0ae9f619e4c678221c1d350f07c38628
+  md5: aa8c5e03c4ba1c6fcd27f9fb6e866666
+  depends:
+  - python >=3.9
+  - wrapt >=1.7.0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/debtcollector?source=hash-mapping
+  size: 22445
+  timestamp: 1734503043687
+- kind: conda
   name: distlib
   version: 0.3.8
   build: pyhd8ed1ab_0
@@ -1095,6 +1773,24 @@ packages:
   size: 274915
   timestamp: 1702383349284
 - kind: conda
+  name: distlib
+  version: 0.3.9
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_1.conda
+  sha256: 0e160c21776bd881b79ce70053e59736f51036784fa43a50da10a04f0c1b9c45
+  md5: 8d88f4a2242e6b96f9ecff9a6a05b2f1
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/distlib?source=hash-mapping
+  size: 274151
+  timestamp: 1733238487461
+- kind: conda
   name: editables
   version: '0.5'
   build: pyhd8ed1ab_0
@@ -1111,6 +1807,24 @@ packages:
   - pkg:pypi/editables?source=hash-mapping
   size: 10988
   timestamp: 1705857085102
+- kind: conda
+  name: editables
+  version: '0.5'
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.5-pyhd8ed1ab_1.conda
+  sha256: 8d4f908e670be360617d418c328213bc46e7100154c3742db085148141712f60
+  md5: 2cf824fe702d88e641eec9f9f653e170
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/editables?source=hash-mapping
+  size: 10828
+  timestamp: 1733208220327
 - kind: conda
   name: environs
   version: 9.5.0
@@ -1147,6 +1861,23 @@ packages:
   size: 20418
   timestamp: 1720869435725
 - kind: conda
+  name: exceptiongroup
+  version: 1.2.2
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_1.conda
+  sha256: cbde2c64ec317118fc06b223c5fd87c8a680255e7348dd60e7b292d2e103e701
+  md5: a16662747cdeb9abbac74d0057cc976e
+  depends:
+  - python >=3.9
+  license: MIT and PSF-2.0
+  purls:
+  - pkg:pypi/exceptiongroup?source=hash-mapping
+  size: 20486
+  timestamp: 1733208916977
+- kind: conda
   name: expat
   version: 2.6.2
   build: h2f0025b_0
@@ -1179,6 +1910,22 @@ packages:
   size: 137627
   timestamp: 1710362144873
 - kind: conda
+  name: expat
+  version: 2.6.4
+  build: h2621725_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/expat-2.6.4-h2621725_0.conda
+  sha256: e2bd3d2f941f04d9707fec791e2147c36346c7d4d6eea46bc9840767ea5c1f15
+  md5: 62d530df254d351df0b8f2365955507b
+  depends:
+  - libexpat 2.6.4 h2621725_0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 145261
+  timestamp: 1730967158904
+- kind: conda
   name: filelock
   version: 3.15.4
   build: pyhd8ed1ab_0
@@ -1194,6 +1941,23 @@ packages:
   - pkg:pypi/filelock?source=hash-mapping
   size: 17592
   timestamp: 1719088395353
+- kind: conda
+  name: filelock
+  version: 3.16.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/filelock-3.16.1-pyhd8ed1ab_1.conda
+  sha256: 18dca6e2194732df7ebf824abaefe999e4765ebe8e8a061269406ab88fc418b9
+  md5: d692e9ba6f92dc51484bf3477e36ce7c
+  depends:
+  - python >=3.9
+  license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=hash-mapping
+  size: 17441
+  timestamp: 1733240909987
 - kind: conda
   name: flask
   version: 2.3.3
@@ -1238,6 +2002,49 @@ packages:
   - pkg:pypi/flask-restful?source=hash-mapping
   size: 29283
   timestamp: 1684644166805
+- kind: conda
+  name: flask-restful
+  version: 0.3.10
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/flask-restful-0.3.10-pyhd8ed1ab_1.conda
+  sha256: 9142324a2078a1d1fac70120be80dab80098f3128435cd21007fcf3c3a902325
+  md5: 2ca4f72106025c84254c63c573bf734f
+  depends:
+  - aniso8601 >=0.82
+  - flask >=0.8
+  - python >=3.9
+  - pytz
+  - six >=1.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/flask-restful?source=hash-mapping
+  size: 29264
+  timestamp: 1734352960237
+- kind: conda
+  name: gunicorn
+  version: 21.2.0
+  build: py312h7864ebf_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/gunicorn-21.2.0-py312h7864ebf_1.conda
+  sha256: b76e3b17aead515230cb1ab28ce6a1c00ad8434aabe1c06530f5c54eef74080f
+  md5: 01cee4c09f0b7ab02e30b01f71095b70
+  depends:
+  - packaging
+  - python >=3.12.0rc2,<3.13.0a0
+  - python >=3.12.0rc2,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - setuptools >=3.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/gunicorn?source=hash-mapping
+  size: 176765
+  timestamp: 1695415016239
 - kind: conda
   name: gunicorn
   version: 21.2.0
@@ -1298,6 +2105,25 @@ packages:
   size: 48251
   timestamp: 1664132995560
 - kind: conda
+  name: h11
+  version: 0.14.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_1.conda
+  sha256: 622516185a7c740d5c7f27016d0c15b45782c1501e5611deec63fd70344ce7c8
+  md5: 7ee49e89531c0dcbba9466f6d115d585
+  depends:
+  - python >=3.9
+  - typing_extensions
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h11?source=hash-mapping
+  size: 51846
+  timestamp: 1733327599467
+- kind: conda
   name: h2
   version: 4.1.0
   build: pyhd8ed1ab_0
@@ -1316,6 +2142,26 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 46754
   timestamp: 1634280590080
+- kind: conda
+  name: h2
+  version: 4.1.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_1.conda
+  sha256: 843ddad410c370672a8250470697027618f104153612439076d4d7b91eeb7b5c
+  md5: 825927dc7b0f287ef8d4d0011bb113b1
+  depends:
+  - hpack >=4.0,<5
+  - hyperframe >=6.0,<7
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h2?source=hash-mapping
+  size: 52000
+  timestamp: 1733298867359
 - kind: conda
   name: hatch
   version: 1.12.0
@@ -1350,6 +2196,40 @@ packages:
   size: 177389
   timestamp: 1716952054661
 - kind: conda
+  name: hatch
+  version: 1.14.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hatch-1.14.0-pyhd8ed1ab_1.conda
+  sha256: 908fc6e847da57da39011be839db0f56f16428d3d950f49a8c7ac1c9c1ed0505
+  md5: b34bdd91d7298c76d9891cea6c8ab27f
+  depends:
+  - click >=8.0.6
+  - hatchling >=1.24.2
+  - httpx >=0.22.0
+  - hyperlink >=21.0.0
+  - keyring >=23.5.0
+  - packaging >=24.2
+  - pexpect >=4.8,<5
+  - platformdirs >=2.5.0
+  - python >=3.9
+  - rich >=11.2.0
+  - shellingham >=1.4.0
+  - tomli-w >=1.0
+  - tomlkit >=0.11.1
+  - userpath >=1.7,<2
+  - uv >=0.1.35
+  - virtualenv >=20.26.6
+  - zstandard <1.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hatch?source=hash-mapping
+  size: 177914
+  timestamp: 1734476985835
+- kind: conda
   name: hatchling
   version: 1.25.0
   build: pyhd8ed1ab_0
@@ -1374,6 +2254,31 @@ packages:
   size: 64580
   timestamp: 1719090878694
 - kind: conda
+  name: hatchling
+  version: 1.27.0
+  build: pypyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.27.0-pypyhd8ed1ab_0.conda
+  sha256: e83420f81390535774ac33b83d05249b8993e5376b76b4d461f83a77549e493d
+  md5: b85c18ba6e927ae0da3fde426c893cc8
+  depends:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - python >=3.8
+  - tomli >=1.2.2
+  - trove-classifiers
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hatchling?source=hash-mapping
+  size: 56598
+  timestamp: 1734311718682
+- kind: conda
   name: hpack
   version: 4.0.0
   build: pyh9f0ad1d_0
@@ -1390,6 +2295,24 @@ packages:
   - pkg:pypi/hpack?source=hash-mapping
   size: 25341
   timestamp: 1598856368685
+- kind: conda
+  name: hpack
+  version: 4.0.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyhd8ed1ab_1.conda
+  sha256: ec89b7e5b8aa2f0219f666084446e1fb7b54545861e9caa892acb24d125761b5
+  md5: 2aa5ff7fa34a81b9196532c84c10d865
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hpack?source=hash-mapping
+  size: 29412
+  timestamp: 1733299296857
 - kind: conda
   name: httpcore
   version: 1.0.5
@@ -1413,6 +2336,28 @@ packages:
   size: 45816
   timestamp: 1711597091407
 - kind: conda
+  name: httpcore
+  version: 1.0.7
+  build: pyh29332c3_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.7-pyh29332c3_1.conda
+  sha256: c84d012a245171f3ed666a8bf9319580c269b7843ffa79f26468842da3abd5df
+  md5: 2ca8e6dbc86525c8b95e3c0ffa26442e
+  depends:
+  - python >=3.8
+  - h11 >=0.13,<0.15
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=3.0,<5.0
+  - certifi
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 48959
+  timestamp: 1731707562362
+- kind: conda
   name: httpx
   version: 0.27.2
   build: pyhd8ed1ab_0
@@ -1435,6 +2380,27 @@ packages:
   size: 65085
   timestamp: 1724778453275
 - kind: conda
+  name: httpx
+  version: 0.28.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  md5: d6989ead454181f4f9bc987d3dc4e285
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/httpx?source=hash-mapping
+  size: 63082
+  timestamp: 1733663449209
+- kind: conda
   name: hyperframe
   version: 6.0.1
   build: pyhd8ed1ab_0
@@ -1451,6 +2417,43 @@ packages:
   - pkg:pypi/hyperframe?source=hash-mapping
   size: 14646
   timestamp: 1619110249723
+- kind: conda
+  name: hyperframe
+  version: 6.0.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_1.conda
+  sha256: e91c6ef09d076e1d9a02819cd00fa7ee18ecf30cdd667605c853980216584d1b
+  md5: 566e75c90c1d0c8c459eb0ad9833dc7a
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/hyperframe?source=hash-mapping
+  size: 17239
+  timestamp: 1733298862681
+- kind: conda
+  name: hyperlink
+  version: 21.0.0
+  build: pyh29332c3_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/hyperlink-21.0.0-pyh29332c3_1.conda
+  sha256: 6fc0a91c590b3055bfb7983e6521c7b780ab8b11025058eaf898049ea827d829
+  md5: c27acdecaf3c311e5781b81fe02d9641
+  depends:
+  - python >=3.9
+  - idna >=2.6
+  - python
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 74751
+  timestamp: 1733319972207
 - kind: conda
   name: hyperlink
   version: 21.0.0
@@ -1487,6 +2490,24 @@ packages:
   size: 49275
   timestamp: 1724450633325
 - kind: conda
+  name: idna
+  version: '3.10'
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_1.conda
+  sha256: d7a472c9fd479e2e8dcb83fb8d433fce971ea369d704ece380e876f9c3494e87
+  md5: 39a4f67be3286c86d696df570b1201b7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=hash-mapping
+  size: 49765
+  timestamp: 1733211921194
+- kind: conda
   name: importlib-metadata
   version: 8.4.0
   build: pyha770c72_0
@@ -1504,6 +2525,25 @@ packages:
   - pkg:pypi/importlib-metadata?source=hash-mapping
   size: 28338
   timestamp: 1724187329246
+- kind: conda
+  name: importlib-metadata
+  version: 8.5.0
+  build: pyha770c72_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_1.conda
+  sha256: 13766b88fc5b23581530d3a0287c0c58ad82f60401afefab283bf158d2be55a9
+  md5: 315607a3030ad5d5227e76e0733798ff
+  depends:
+  - python >=3.9
+  - zipp >=0.5
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-metadata?source=hash-mapping
+  size: 28623
+  timestamp: 1733223207185
 - kind: conda
   name: importlib_metadata
   version: 8.4.0
@@ -1541,6 +2581,27 @@ packages:
   size: 32258
   timestamp: 1724314749050
 - kind: conda
+  name: importlib_resources
+  version: 6.4.5
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.4.5-pyhd8ed1ab_1.conda
+  sha256: 461199e429a3db01f0a673f8beaac5e0be75b88895952fb9183f2ab01c5c3c24
+  md5: 15798fa69312d433af690c8c42b3fb36
+  depends:
+  - python >=3.9
+  - zipp >=3.1.0
+  constrains:
+  - importlib-resources >=6.4.5,<6.4.6.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/importlib-resources?source=hash-mapping
+  size: 32701
+  timestamp: 1733231441973
+- kind: conda
   name: iniconfig
   version: 2.0.0
   build: pyhd8ed1ab_0
@@ -1557,6 +2618,24 @@ packages:
   - pkg:pypi/iniconfig?source=hash-mapping
   size: 11101
   timestamp: 1673103208955
+- kind: conda
+  name: iniconfig
+  version: 2.0.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
+  sha256: 0ec8f4d02053cd03b0f3e63168316530949484f80e16f5e2fb199a1d117a89ca
+  md5: 6837f3eff7dcea42ecd714ce1ac2b108
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/iniconfig?source=hash-mapping
+  size: 11474
+  timestamp: 1733223232820
 - kind: conda
   name: iso8601
   version: 2.1.0
@@ -1575,6 +2654,24 @@ packages:
   size: 13082
   timestamp: 1696327850515
 - kind: conda
+  name: iso8601
+  version: 2.1.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/iso8601-2.1.0-pyhd8ed1ab_1.conda
+  sha256: bdfd0191d791f1b55d89ddafbec80a7ac9b5526e9a79053246996ecf1dc3e8f6
+  md5: 29370dfa863fe2b6af79888a35f2da0d
+  depends:
+  - python >=3.9,<4
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/iso8601?source=hash-mapping
+  size: 12985
+  timestamp: 1733244992622
+- kind: conda
   name: itsdangerous
   version: 2.2.0
   build: pyhd8ed1ab_0
@@ -1591,6 +2688,24 @@ packages:
   - pkg:pypi/itsdangerous?source=hash-mapping
   size: 19333
   timestamp: 1713372766463
+- kind: conda
+  name: itsdangerous
+  version: 2.2.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
+  sha256: 1684b7b16eec08efef5302ce298c606b163c18272b69a62b666fbaa61516f170
+  md5: 7ac5f795c15f288984e32add616cdc59
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/itsdangerous?source=hash-mapping
+  size: 19180
+  timestamp: 1733308353037
 - kind: conda
   name: jaraco.classes
   version: 3.4.0
@@ -1611,6 +2726,25 @@ packages:
   size: 12223
   timestamp: 1713939433204
 - kind: conda
+  name: jaraco.classes
+  version: 3.4.0
+  build: pyhd8ed1ab_2
+  build_number: 2
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.4.0-pyhd8ed1ab_2.conda
+  sha256: 3d16a0fa55a29fe723c918a979b2ee927eb0bf9616381cdfd26fa9ea2b649546
+  md5: ade6b25a6136661dadd1a43e4350b10b
+  depends:
+  - more-itertools
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jaraco-classes?source=hash-mapping
+  size: 12109
+  timestamp: 1733326001034
+- kind: conda
   name: jaraco.context
   version: 5.3.0
   build: pyhd8ed1ab_1
@@ -1630,6 +2764,24 @@ packages:
   size: 12456
   timestamp: 1714372284922
 - kind: conda
+  name: jaraco.context
+  version: 6.0.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.1-pyhd8ed1ab_0.conda
+  sha256: bfaba92cd33a0ae2488ab64a1d4e062bcf52b26a71f88292c62386ccac4789d7
+  md5: bcc023a32ea1c44a790bbf1eae473486
+  depends:
+  - backports.tarfile
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jaraco-context?source=hash-mapping
+  size: 12483
+  timestamp: 1733382698758
+- kind: conda
   name: jaraco.functools
   version: 4.0.0
   build: pyhd8ed1ab_0
@@ -1647,6 +2799,24 @@ packages:
   - pkg:pypi/jaraco-functools?source=hash-mapping
   size: 15192
   timestamp: 1701695329516
+- kind: conda
+  name: jaraco.functools
+  version: 4.1.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.1.0-pyhd8ed1ab_0.conda
+  sha256: 61da3e37149da5c8479c21571eaec61cc4a41678ee872dcb2ff399c30878dddb
+  md5: eb257d223050a5a27f5fdf5c9debc8ec
+  depends:
+  - more-itertools
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jaraco-functools?source=hash-mapping
+  size: 15545
+  timestamp: 1733746481844
 - kind: conda
   name: jeepney
   version: 0.8.0
@@ -1683,6 +2853,25 @@ packages:
   size: 111565
   timestamp: 1715127275924
 - kind: conda
+  name: jinja2
+  version: 3.1.4
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_1.conda
+  sha256: 85a7169c078b8065bd9d121b0e7b99c8b88c42a411314b6ae5fcd81c48c4710a
+  md5: 08cce3151bde4ecad7885bd9fb647532
+  depends:
+  - markupsafe >=2.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jinja2?source=hash-mapping
+  size: 110963
+  timestamp: 1733217424408
+- kind: conda
   name: keyring
   version: 25.3.0
   build: pyha804496_0
@@ -1707,6 +2896,32 @@ packages:
   - pkg:pypi/keyring?source=hash-mapping
   size: 36643
   timestamp: 1722727332948
+- kind: conda
+  name: keyring
+  version: 25.5.0
+  build: pyha804496_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/keyring-25.5.0-pyha804496_1.conda
+  sha256: 0f15886df2dfdd7474fc15b9bf890669cbfd0becb0072eafb9a3ba1e949d9a57
+  md5: 8067b23a97d7ee4bb0fd81500ba4bbe3
+  depends:
+  - __linux
+  - importlib-metadata >=4.11.4
+  - importlib_resources
+  - jaraco.classes
+  - jaraco.context
+  - jaraco.functools
+  - jeepney >=0.4.2
+  - python >=3.9
+  - secretstorage >=3.2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/keyring?source=hash-mapping
+  size: 37016
+  timestamp: 1733418412922
 - kind: conda
   name: keystoneauth1
   version: 4.3.1
@@ -1763,6 +2978,22 @@ packages:
   size: 735885
   timestamp: 1718625653417
 - kind: conda
+  name: ld_impl_linux-ppc64le
+  version: '2.43'
+  build: h5c2c55b_2
+  build_number: 2
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.43-h5c2c55b_2.conda
+  sha256: 68a07caa30876a49d06b5b1b5fd4ed3fe09c82caa7e7e3dbe93fd177f09c2f1b
+  md5: 4519631f51d944ce5a1282216e571d49
+  constrains:
+  - binutils_impl_linux-ppc64le 2.43
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 695692
+  timestamp: 1729655468502
+- kind: conda
   name: libexpat
   version: 2.6.2
   build: h2f0025b_0
@@ -1797,6 +3028,23 @@ packages:
   size: 73730
   timestamp: 1710362120304
 - kind: conda
+  name: libexpat
+  version: 2.6.4
+  build: h2621725_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libexpat-2.6.4-h2621725_0.conda
+  sha256: 313176c5fa1fd2ef6b91346510d1d1d6977534e23c428a09467474d187ff530e
+  md5: 544bdff04aec471ccd22454615f7ddac
+  depends:
+  - libgcc >=13
+  constrains:
+  - expat 2.6.4.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 83419
+  timestamp: 1730967149052
+- kind: conda
   name: libffi
   version: 3.4.2
   build: h3557bc0_5
@@ -1812,6 +3060,22 @@ packages:
   purls: []
   size: 59450
   timestamp: 1636488255090
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h4e0d66e_5
+  build_number: 5
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2
+  sha256: 178ca9f82e2144a8834dd01f9af3b4b9b5d482892675931edccff06aee524953
+  md5: 79c37a0a50ef77fea4ee5f6d257b8b3c
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 64043
+  timestamp: 1636488304057
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -1868,6 +3132,26 @@ packages:
   size: 533503
   timestamp: 1724802540921
 - kind: conda
+  name: libgcc
+  version: 14.2.0
+  build: h31e42bb_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-14.2.0-h31e42bb_1.conda
+  sha256: c072f6417881050e9efd108a8fc5696b672f0d29ffa93c9735fbd130ccf5707f
+  md5: 3a072f9f5f27732202ae3baeb7ece426
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 14.2.0 h31e42bb_1
+  - libgcc-ng ==14.2.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 760598
+  timestamp: 1729088648691
+- kind: conda
   name: libgcc-ng
   version: 14.1.0
   build: h69a702a_1
@@ -1899,6 +3183,22 @@ packages:
   purls: []
   size: 52203
   timestamp: 1724802545317
+- kind: conda
+  name: libgcc-ng
+  version: 14.2.0
+  build: hfdc3801_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-14.2.0-hfdc3801_1.conda
+  sha256: c0af04696a13291735f8970b2e8bb0aab8924e0cd82e55edb321a12f16158967
+  md5: efb9c5003a48f3e9e701aca3c2db02e5
+  depends:
+  - libgcc 14.2.0 h31e42bb_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 54181
+  timestamp: 1729088656555
 - kind: conda
   name: libglib
   version: 2.80.3
@@ -1943,6 +3243,26 @@ packages:
   size: 4016353
   timestamp: 1723208981686
 - kind: conda
+  name: libglib
+  version: 2.82.2
+  build: h3d6172d_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libglib-2.82.2-h3d6172d_0.conda
+  sha256: 9059461b160a540a5f68864310051c1416bca1f6278d357fcd20909279e8cc00
+  md5: 02335a62448b0531202a5a930da34d91
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.44,<10.45.0a0
+  constrains:
+  - glib 2.82.2 *_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 4075120
+  timestamp: 1729191528923
+- kind: conda
   name: libgomp
   version: 14.1.0
   build: h77fa898_1
@@ -1973,6 +3293,22 @@ packages:
   size: 461429
   timestamp: 1724802428910
 - kind: conda
+  name: libgomp
+  version: 14.2.0
+  build: h31e42bb_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-14.2.0-h31e42bb_1.conda
+  sha256: 61d9d02bcc3fc9fd9ae33d46456a575498dbf487a19e04f5c9b61fa7813d16b1
+  md5: 73233dde3c3ff3950b0df42a6ba466bf
+  depends:
+  - _libgcc_mutex 0.1 conda_forge
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 466670
+  timestamp: 1729088574800
+- kind: conda
   name: libiconv
   version: '1.17'
   build: h31becfc_2
@@ -1990,6 +3326,21 @@ packages:
 - kind: conda
   name: libiconv
   version: '1.17'
+  build: ha17a0cc_2
+  build_number: 2
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libiconv-1.17-ha17a0cc_2.conda
+  sha256: 4b05af88c67b94f4bd574e4323a5214a13499bd5945cb8c9409fcd3021fb538c
+  md5: 57fa947d903914bc16c5e96f28b885ba
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  purls: []
+  size: 718302
+  timestamp: 1702684843655
+- kind: conda
+  name: libiconv
+  version: '1.17'
   build: hd590300_2
   build_number: 2
   subdir: linux-64
@@ -2002,6 +3353,36 @@ packages:
   purls: []
   size: 705775
   timestamp: 1702682170569
+- kind: conda
+  name: liblzma
+  version: 5.6.3
+  build: h190368a_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/liblzma-5.6.3-h190368a_1.conda
+  sha256: 92fb203e9eae5f4d49f913e5e5ffc283b82992c306bcc27483e0d3e324716046
+  md5: f6e2ef23412236071f8b0b930d89fab4
+  depends:
+  - libgcc >=13
+  license: 0BSD
+  purls: []
+  size: 139126
+  timestamp: 1733408980757
+- kind: conda
+  name: libmpdec
+  version: 4.0.0
+  build: h1f2b957_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libmpdec-4.0.0-h1f2b957_0.conda
+  sha256: 8b66ef1c752097f93136ef68e4b565182ab66045a620753927d3ab868ec2eb5a
+  md5: 54477b2cf1e9d27af837223c73dbedcd
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 121586
+  timestamp: 1723861260620
 - kind: conda
   name: libnsl
   version: 2.0.1
@@ -2017,6 +3398,21 @@ packages:
   purls: []
   size: 34501
   timestamp: 1697358973269
+- kind: conda
+  name: libnsl
+  version: 2.0.1
+  build: ha17a0cc_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libnsl-2.0.1-ha17a0cc_0.conda
+  sha256: 74ac0af4fd8eab7ef703b4d3fff4157e710c1e09b430d8bee010f6dcb0801a86
+  md5: fff1c88a9eb0409f33ff9eba62c2d211
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  license_family: GPL
+  purls: []
+  size: 35804
+  timestamp: 1697359195099
 - kind: conda
   name: libnsl
   version: 2.0.1
@@ -2063,6 +3459,21 @@ packages:
   size: 1043861
   timestamp: 1718050586624
 - kind: conda
+  name: libsqlite
+  version: 3.47.2
+  build: haeeb200_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.47.2-haeeb200_0.conda
+  sha256: 376a180ac4444ecc0b76e284a0007d5cb18915fe204854a73d2fdfd60d844cba
+  md5: 856f7c6dbae028289dd70a61ea07fe9d
+  depends:
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  purls: []
+  size: 1169279
+  timestamp: 1733761921475
+- kind: conda
   name: libstdcxx
   version: 14.1.0
   build: h3f4de04_1
@@ -2094,6 +3505,22 @@ packages:
   purls: []
   size: 3892781
   timestamp: 1724801863728
+- kind: conda
+  name: libstdcxx
+  version: 14.2.0
+  build: h262982c_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-14.2.0-h262982c_1.conda
+  sha256: 3677b0c612ea44344e8a9557739d6b7a012c9def8596a23e354c25655509ef14
+  md5: 5cd9d61c4b3ac04ab92fe6594db37e73
+  depends:
+  - libgcc 14.2.0 h31e42bb_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 4020468
+  timestamp: 1729088674366
 - kind: conda
   name: libstdcxx-ng
   version: 14.1.0
@@ -2127,6 +3554,22 @@ packages:
   size: 52240
   timestamp: 1724802596264
 - kind: conda
+  name: libstdcxx-ng
+  version: 14.2.0
+  build: hf27a640_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-ng-14.2.0-hf27a640_1.conda
+  sha256: 29b7de3d3113813dad544e2d877dd45a5887caef011a89d4046975b82a5ea308
+  md5: c425d57bca99841a433304abb6b2b670
+  depends:
+  - libstdcxx 14.2.0 h262982c_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 54231
+  timestamp: 1729088707256
+- kind: conda
   name: libuuid
   version: 2.38.1
   build: h0b41bf4_0
@@ -2141,6 +3584,21 @@ packages:
   purls: []
   size: 33601
   timestamp: 1680112270483
+- kind: conda
+  name: libuuid
+  version: 2.38.1
+  build: h4194056_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.38.1-h4194056_0.conda
+  sha256: c346f9f9b8ffdeced94cfe90e6188b822f43c684eeee9803105fbe1d7d12c394
+  md5: fed50db9b0ea36487e89a6935ca87a94
+  depends:
+  - libgcc-ng >=12
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 39481
+  timestamp: 1680113767606
 - kind: conda
   name: libuuid
   version: 2.38.1
@@ -2174,6 +3632,21 @@ packages:
 - kind: conda
   name: libxcrypt
   version: 4.4.36
+  build: ha17a0cc_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libxcrypt-4.4.36-ha17a0cc_1.conda
+  sha256: 9ac5f759e8aade50c37fc26c1c050e87943538ea97e21f243fd72156055aba31
+  md5: b8d12a4079c614d8852c6a310fa61a80
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 124052
+  timestamp: 1702725129071
+- kind: conda
+  name: libxcrypt
+  version: 4.4.36
   build: hd590300_1
   build_number: 1
   subdir: linux-64
@@ -2186,6 +3659,24 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
+- kind: conda
+  name: libzlib
+  version: 1.3.1
+  build: h190368a_2
+  build_number: 2
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.3.1-h190368a_2.conda
+  sha256: 05216f74566f6ede1161c99fc4fbbcc9ca9095069c81c937e6384582cefe49c9
+  md5: 4ac019aac4dbff4728ef133b8ec3a913
+  depends:
+  - libgcc >=13
+  constrains:
+  - zlib 1.3.1 *_2
+  license: Zlib
+  license_family: Other
+  purls: []
+  size: 69388
+  timestamp: 1727963207653
 - kind: conda
   name: libzlib
   version: 1.3.1
@@ -2241,6 +3732,25 @@ packages:
   size: 64356
   timestamp: 1686175179621
 - kind: conda
+  name: markdown-it-py
+  version: 3.0.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
+  sha256: 0fbacdfb31e55964152b24d5567e9a9996e1e7902fb08eb7d91b5fd6ce60803a
+  md5: fee3164ac23dfca50cfcc8b85ddefb81
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/markdown-it-py?source=hash-mapping
+  size: 64430
+  timestamp: 1733250550053
+- kind: conda
   name: markupsafe
   version: 2.1.5
   build: py312h98912ed_0
@@ -2281,6 +3791,48 @@ packages:
   size: 27435
   timestamp: 1706901498578
 - kind: conda
+  name: markupsafe
+  version: 3.0.2
+  build: py312h1d80cea_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/markupsafe-3.0.2-py312h1d80cea_1.conda
+  sha256: d8b90e22e5eb8e8cc7590390fd4f87ea4f85b6baf6639e184c37def4e7af2a23
+  md5: 627ff740d9f5e82b51035331aa5f8a0c
+  depends:
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 25426
+  timestamp: 1733220401078
+- kind: conda
+  name: markupsafe
+  version: 3.0.2
+  build: py313h1d1471b_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/markupsafe-3.0.2-py313h1d1471b_1.conda
+  sha256: 2c5aeb409f32391dec79a220ee66cf2323807ed1cc22c34a5dc4c4e99e818f0c
+  md5: 3a3916fd206a5d4bf16c49a9d2d27c23
+  depends:
+  - libgcc >=13
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 25975
+  timestamp: 1733220881607
+- kind: conda
   name: marshmallow
   version: 3.22.0
   build: pyhd8ed1ab_0
@@ -2297,6 +3849,23 @@ packages:
   - pkg:pypi/marshmallow?source=hash-mapping
   size: 92188
   timestamp: 1724261086984
+- kind: conda
+  name: marshmallow
+  version: 3.23.2
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/marshmallow-3.23.2-pyhd8ed1ab_0.conda
+  sha256: 799cef8b62a58e3a8be4571f43694369c369e7710f5402f17364961509f49110
+  md5: db9b53bd42cfdba9e1a8d4b353c69a26
+  depends:
+  - packaging >=17.0
+  - python >=3.9
+  license: MIT AND BSD-3-Clause
+  purls:
+  - pkg:pypi/marshmallow?source=hash-mapping
+  size: 92373
+  timestamp: 1734616433297
 - kind: conda
   name: mdurl
   version: 0.1.2
@@ -2315,6 +3884,24 @@ packages:
   size: 14680
   timestamp: 1704317789138
 - kind: conda
+  name: mdurl
+  version: 0.1.2
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mdurl?source=hash-mapping
+  size: 14465
+  timestamp: 1733255681319
+- kind: conda
   name: more-itertools
   version: 10.4.0
   build: pyhd8ed1ab_0
@@ -2331,6 +3918,24 @@ packages:
   - pkg:pypi/more-itertools?source=hash-mapping
   size: 57380
   timestamp: 1723055591256
+- kind: conda
+  name: more-itertools
+  version: 10.5.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.5.0-pyhd8ed1ab_1.conda
+  sha256: ccb385f3a25efb47e9ea9870b0fa67b05c3b40c4c695e5f3946ab12e79e3096d
+  md5: 206f67a1eccc290e5679bb793c3eb17e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/more-itertools?source=hash-mapping
+  size: 57541
+  timestamp: 1733662695649
 - kind: conda
   name: msgpack-python
   version: 1.0.8
@@ -2371,6 +3976,46 @@ packages:
   size: 101625
   timestamp: 1715670814892
 - kind: conda
+  name: msgpack-python
+  version: 1.1.0
+  build: py312hc0892ed_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/msgpack-python-1.1.0-py312hc0892ed_0.conda
+  sha256: fe74a6479859a0336729973bd114cda128659a815cae898100483708c24b9975
+  md5: 0ace725bbc1ce769e65c448c13e678af
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/msgpack?source=hash-mapping
+  size: 108321
+  timestamp: 1725975239870
+- kind: conda
+  name: msgpack-python
+  version: 1.1.0
+  build: py313ha5143e8_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/msgpack-python-1.1.0-py313ha5143e8_0.conda
+  sha256: 90a40638eabce4695bbfb2e9e02259960369fcd4946b898eb8063daf2eadaa92
+  md5: 7a13472fcd516f8b9d92391726644542
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.13.0rc2,<3.14.0a0
+  - python >=3.13.0rc2,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/msgpack?source=hash-mapping
+  size: 108588
+  timestamp: 1725975243354
+- kind: conda
   name: ncurses
   version: '6.5'
   build: hcccb83c_1
@@ -2385,6 +4030,21 @@ packages:
   purls: []
   size: 924472
   timestamp: 1724658573518
+- kind: conda
+  name: ncurses
+  version: '6.5'
+  build: hd444e8b_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.5-hd444e8b_1.conda
+  sha256: 00a89f96063a5197204d0d86d34bdb8c68f34d5dd97dd6892d53869ab6853cd7
+  md5: 1aa1f96b73059bb9294e881e371ccbd4
+  depends:
+  - libgcc-ng >=12
+  license: X11 AND BSD-3-Clause
+  purls: []
+  size: 995390
+  timestamp: 1724658668070
 - kind: conda
   name: ncurses
   version: '6.5'
@@ -2418,6 +4078,24 @@ packages:
   - pkg:pypi/netaddr?source=hash-mapping
   size: 1535240
   timestamp: 1722975623594
+- kind: conda
+  name: netaddr
+  version: 1.3.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/netaddr-1.3.0-pyhd8ed1ab_1.conda
+  sha256: 129eedcf6bcdf7f572cf6ae601d0e4fe96f1073949a5ed4b2851a741c2e39a02
+  md5: 764473f3d826efc53ddd7dd9ef53f022
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/netaddr?source=hash-mapping
+  size: 1532484
+  timestamp: 1734502796812
 - kind: conda
   name: netifaces
   version: 0.11.0
@@ -2493,6 +4171,22 @@ packages:
   size: 2892042
   timestamp: 1724402701933
 - kind: conda
+  name: openssl
+  version: 3.4.0
+  build: h190368a_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.4.0-h190368a_0.conda
+  sha256: e50f2f844dac1a1a61a5946c4470bdc7ef189367b8d4ca51a6cbf3995aa6b40e
+  md5: 397b9dbfbc0642b40043e2d333698b95
+  depends:
+  - ca-certificates
+  - libgcc >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3125894
+  timestamp: 1731379713539
+- kind: conda
   name: os-service-types
   version: 1.7.0
   build: pyh9f0ad1d_0
@@ -2510,6 +4204,25 @@ packages:
   - pkg:pypi/os-service-types?source=hash-mapping
   size: 20190
   timestamp: 1586640371135
+- kind: conda
+  name: os-service-types
+  version: 1.7.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/os-service-types-1.7.0-pyhd8ed1ab_1.conda
+  sha256: 83720d2fd80560b6ff4cdd93f182c331fb0aa01332beace83bbcadb3987c43d5
+  md5: 6f4324d49bc352ab3b73d7977959a4e0
+  depends:
+  - pbr !=2.1.0,>=2.0.0
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/os-service-types?source=hash-mapping
+  size: 22292
+  timestamp: 1734526595038
 - kind: conda
   name: oslo.config
   version: 9.6.0
@@ -2535,6 +4248,31 @@ packages:
   size: 101360
   timestamp: 1724768511337
 - kind: conda
+  name: oslo.config
+  version: 9.7.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/oslo.config-9.7.0-pyhd8ed1ab_1.conda
+  sha256: eda8c3b46c3f1c618cc122a882710255778b233ab5e356f58eb63cbe07361d47
+  md5: 5e0c8d60bf569dd8858c27c4bc35aaff
+  depends:
+  - debtcollector >=1.2.0
+  - netaddr >=0.7.18
+  - oslo.i18n >=3.15.3
+  - python >=3.9
+  - pyyaml >=5.1
+  - requests >=2.18.0
+  - rfc3986 >=1.2.0
+  - stevedore >=1.20.0
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/oslo-config?source=hash-mapping
+  size: 101398
+  timestamp: 1734686839790
+- kind: conda
   name: oslo.i18n
   version: 6.4.0
   build: pyhd8ed1ab_0
@@ -2552,6 +4290,25 @@ packages:
   - pkg:pypi/oslo-i18n?source=hash-mapping
   size: 32575
   timestamp: 1724768577209
+- kind: conda
+  name: oslo.i18n
+  version: 6.5.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/oslo.i18n-6.5.0-pyhd8ed1ab_1.conda
+  sha256: 2fbedfad40b6a623533d2f1e1e1144eaf592d2472ddef882925a202f8cafbad0
+  md5: 005d65dcf9a48e33453727106ce789b9
+  depends:
+  - pbr !=2.1.0,>=2.0.0
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/oslo-i18n?source=hash-mapping
+  size: 32756
+  timestamp: 1734502607951
 - kind: conda
   name: oslo.serialization
   version: 5.5.0
@@ -2573,6 +4330,28 @@ packages:
   - pkg:pypi/oslo-serialization?source=hash-mapping
   size: 24099
   timestamp: 1723722675212
+- kind: conda
+  name: oslo.serialization
+  version: 5.6.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/oslo.serialization-5.6.0-pyhd8ed1ab_1.conda
+  sha256: af99b195bc29c444b9dca74bb0941698e3461c13d47a7af626ee7c2df658b614
+  md5: 4325ba4a2cf4873995322885c044e1c2
+  depends:
+  - msgpack-python
+  - oslo.utils
+  - pbr
+  - python >=3.9
+  - pytz
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/oslo-serialization?source=hash-mapping
+  size: 24185
+  timestamp: 1734686853588
 - kind: conda
   name: oslo.utils
   version: 7.3.0
@@ -2601,6 +4380,33 @@ packages:
   size: 96305
   timestamp: 1724768421418
 - kind: conda
+  name: oslo.utils
+  version: 8.0.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/oslo.utils-8.0.0-pyhd8ed1ab_1.conda
+  sha256: ebfe68f5ba5eead944076c1533a29866b20f0b50d3fc4d2396f428eb0e339e79
+  md5: 43852960d83f7c0d32d3bdd5d821662f
+  depends:
+  - debtcollector >=1.2.0
+  - iso8601 >=0.1.11
+  - netaddr >=0.10.0
+  - oslo.i18n >=3.15.3
+  - packaging >=20.4
+  - psutil >=3.2.2
+  - pyparsing >=2.1.0
+  - python >=3.9
+  - python-tzdata >=2022.4
+  - pyyaml >=3.13
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/oslo-utils?source=hash-mapping
+  size: 99663
+  timestamp: 1734502572153
+- kind: conda
   name: packaging
   version: '24.1'
   build: pyhd8ed1ab_0
@@ -2618,6 +4424,24 @@ packages:
   size: 50290
   timestamp: 1718189540074
 - kind: conda
+  name: packaging
+  version: '24.2'
+  build: pyhd8ed1ab_2
+  build_number: 2
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_2.conda
+  sha256: da157b19bcd398b9804c5c52fc000fcb8ab0525bdb9c70f95beaa0bb42f85af1
+  md5: 3bfed7e6228ebf2f7b9eaa47f1b4e2aa
+  depends:
+  - python >=3.8
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/packaging?source=hash-mapping
+  size: 60164
+  timestamp: 1733203368787
+- kind: conda
   name: pathspec
   version: 0.12.1
   build: pyhd8ed1ab_0
@@ -2634,6 +4458,24 @@ packages:
   - pkg:pypi/pathspec?source=hash-mapping
   size: 41173
   timestamp: 1702250135032
+- kind: conda
+  name: pathspec
+  version: 0.12.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pathspec-0.12.1-pyhd8ed1ab_1.conda
+  sha256: 9f64009cdf5b8e529995f18e03665b03f5d07c0b17445b8badef45bde76249ee
+  md5: 617f15191456cc6a13db418a275435e5
+  depends:
+  - python >=3.9
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls:
+  - pkg:pypi/pathspec?source=hash-mapping
+  size: 41075
+  timestamp: 1733233471940
 - kind: conda
   name: pbr
   version: 6.1.0
@@ -2653,6 +4495,25 @@ packages:
   size: 73891
   timestamp: 1724777732325
 - kind: conda
+  name: pbr
+  version: 6.1.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pbr-6.1.0-pyhd8ed1ab_1.conda
+  sha256: fdf21121ed47d743f84df5c4d03114ab6d9de32c784508dbe2e0e68f0ac6715a
+  md5: 9f71c0894cfc53f2bfd2703bb3dccb0d
+  depends:
+  - pip
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/pbr?source=hash-mapping
+  size: 74046
+  timestamp: 1733933905431
+- kind: conda
   name: pcre2
   version: '10.44'
   build: h070dd5b_2
@@ -2670,6 +4531,24 @@ packages:
   purls: []
   size: 884590
   timestamp: 1723488793100
+- kind: conda
+  name: pcre2
+  version: '10.44'
+  build: h3dd95db_2
+  build_number: 2
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/pcre2-10.44-h3dd95db_2.conda
+  sha256: 61ae7df16115343dd88a10a4fb67a767876caee65a5724d86f3679c0e36002ba
+  md5: b9fb95c4bf3f2a43a8eb517199b93632
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 937416
+  timestamp: 1723488830064
 - kind: conda
   name: pcre2
   version: '10.44'
@@ -2706,11 +4585,29 @@ packages:
   - pkg:pypi/pexpect?source=hash-mapping
   size: 53600
   timestamp: 1706113273252
+- kind: conda
+  name: pexpect
+  version: 4.9.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+  sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
+  md5: d0d408b1f18883a944376da5cf8101ea
+  depends:
+  - ptyprocess >=0.5
+  - python >=3.9
+  license: ISC
+  purls:
+  - pkg:pypi/pexpect?source=hash-mapping
+  size: 53561
+  timestamp: 1733302019362
 - kind: pypi
   name: pfcon
   version: 0.0.0+unknown
   path: .
-  sha256: 51a5843155fa5e338a8b5674ca689e9d42daacc9937fcfd7d5851a9c59586b93
+  sha256: 919ed0916c15e1795312d70fbe1bd15bfdc3fa0c40fcc757eeddc4afbbe33c55
   requires_python: '>=3.11'
   editable: true
 - kind: conda
@@ -2733,6 +4630,44 @@ packages:
   size: 1238498
   timestamp: 1722451042495
 - kind: conda
+  name: pip
+  version: 24.3.1
+  build: pyh145f28c_2
+  build_number: 2
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh145f28c_2.conda
+  sha256: 7a300e856215180d292f85d40708164cd19dfcdb521ecacb894daa81f13994d7
+  md5: 76601b0ccfe1fe13a21a5f8813cb38de
+  depends:
+  - python >=3.13.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pip?source=hash-mapping
+  size: 1242403
+  timestamp: 1734466282846
+- kind: conda
+  name: pip
+  version: 24.3.1
+  build: pyh8b19718_2
+  build_number: 2
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+  sha256: da8c8888de10c1e4234ebcaa1550ac2b4b5408ac20f093fe641e4bc8c9c9f3eb
+  md5: 04e691b9fadd93a8a9fad87a81d4fd8f
+  depends:
+  - python >=3.9,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pip?source=hash-mapping
+  size: 1245116
+  timestamp: 1734466348103
+- kind: conda
   name: platformdirs
   version: 4.2.2
   build: pyhd8ed1ab_0
@@ -2749,6 +4684,24 @@ packages:
   - pkg:pypi/platformdirs?source=hash-mapping
   size: 20572
   timestamp: 1715777739019
+- kind: conda
+  name: platformdirs
+  version: 4.3.6
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.6-pyhd8ed1ab_1.conda
+  sha256: bb50f6499e8bc1d1a26f17716c97984671121608dc0c3ecd34858112bce59a27
+  md5: 577852c7e53901ddccc7e6a9959ddebe
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/platformdirs?source=hash-mapping
+  size: 20448
+  timestamp: 1733232756001
 - kind: conda
   name: pluggy
   version: 1.5.0
@@ -2767,6 +4720,62 @@ packages:
   size: 23815
   timestamp: 1713667175451
 - kind: conda
+  name: pluggy
+  version: 1.5.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.5.0-pyhd8ed1ab_1.conda
+  sha256: 122433fc5318816b8c69283aaf267c73d87aa2d09ce39f64c9805c9a3b264819
+  md5: e9dcbce5f45f9ee500e728ae58b605b6
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pluggy?source=hash-mapping
+  size: 23595
+  timestamp: 1733222855563
+- kind: conda
+  name: psutil
+  version: 6.1.0
+  build: py312h2984477_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/psutil-6.1.0-py312h2984477_0.conda
+  sha256: 8fe6677e55bb97fc6009b9ca2b1e79953b878eb5f7512f4636292757aa42d9bc
+  md5: 9989fdd921a099c41007a55cb3dc987b
+  depends:
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 488627
+  timestamp: 1729847219487
+- kind: conda
+  name: psutil
+  version: 6.1.0
+  build: py313h7aac8da_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/psutil-6.1.0-py313h7aac8da_0.conda
+  sha256: 659d829cdd78e3454a5d8b488a548b820d0000d7829c237140c1428e82c21168
+  md5: b39188df569ead9a4bbe8f22ae4b3a93
+  depends:
+  - libgcc >=13
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 495301
+  timestamp: 1729847282467
+- kind: conda
   name: ptyprocess
   version: 0.7.0
   build: pyhd3deb0d_0
@@ -2782,6 +4791,41 @@ packages:
   - pkg:pypi/ptyprocess?source=hash-mapping
   size: 16546
   timestamp: 1609419417991
+- kind: conda
+  name: ptyprocess
+  version: 0.7.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+  sha256: a7713dfe30faf17508ec359e0bc7e0983f5d94682492469bd462cdaae9c64d83
+  md5: 7d9daffbb8d8e0af0f769dbbcd173a54
+  depends:
+  - python >=3.9
+  license: ISC
+  purls:
+  - pkg:pypi/ptyprocess?source=hash-mapping
+  size: 19457
+  timestamp: 1733302371990
+- kind: conda
+  name: pycparser
+  version: '2.22'
+  build: pyh29332c3_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+  sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
+  md5: 12c566707c80111f9799308d9e265aef
+  depends:
+  - python >=3.9
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 110100
+  timestamp: 1733195786147
 - kind: conda
   name: pycparser
   version: '2.22'
@@ -2817,6 +4861,24 @@ packages:
   size: 879295
   timestamp: 1714846885370
 - kind: conda
+  name: pygments
+  version: 2.18.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.18.0-pyhd8ed1ab_1.conda
+  sha256: 0d6133545f268b2b89c2617c196fc791f365b538d4057ecd636d658c3b1e885d
+  md5: b38dc0206e2a530e5c2cf11dc086b31a
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=hash-mapping
+  size: 876700
+  timestamp: 1733221731178
+- kind: conda
   name: pyjwt
   version: 2.8.0
   build: pyhd8ed1ab_1
@@ -2828,6 +4890,7 @@ packages:
   md5: 74f76d4868dbba5870f2cf1d9b12d8f3
   depends:
   - python >=3.7
+  - typing_extensions
   constrains:
   - cryptography >=3.3.1
   license: MIT
@@ -2854,6 +4917,24 @@ packages:
   size: 90129
   timestamp: 1724616224956
 - kind: conda
+  name: pyparsing
+  version: 3.2.0
+  build: pyhd8ed1ab_2
+  build_number: 2
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.0-pyhd8ed1ab_2.conda
+  sha256: 09a5484532e24a33649ab612674fd0857bbdcfd6640a79d13a6690fb742a36e1
+  md5: 4c05a2bcf87bb495512374143b57cf28
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyparsing?source=hash-mapping
+  size: 92319
+  timestamp: 1733222687746
+- kind: conda
   name: pysocks
   version: 1.7.1
   build: pyha2e5f31_6
@@ -2872,6 +4953,25 @@ packages:
   - pkg:pypi/pysocks?source=hash-mapping
   size: 18981
   timestamp: 1661604969727
+- kind: conda
+  name: pysocks
+  version: 1.7.1
+  build: pyha55dd90_7
+  build_number: 7
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+  md5: 461219d1a5bd61342293efa2c0c90eac
+  depends:
+  - __unix
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pysocks?source=hash-mapping
+  size: 21085
+  timestamp: 1733217331982
 - kind: conda
   name: pytest
   version: 7.4.4
@@ -2961,6 +5061,68 @@ packages:
   size: 13724462
   timestamp: 1723141768383
 - kind: conda
+  name: python
+  version: 3.12.8
+  build: he016669_1_cpython
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/python-3.12.8-he016669_1_cpython.conda
+  sha256: 5babe9db98743fdeda5505a1bf61ea49fd2c5b9cc95327b35cfe7486063bdcc5
+  md5: 356ca7f5d1e70fba1a4799a46b9163e8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-ppc64le >=2.36.1
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  purls: []
+  size: 14086622
+  timestamp: 1733408023063
+- kind: conda
+  name: python
+  version: 3.13.1
+  build: hecb7ae0_102_cp313
+  build_number: 102
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/python-3.13.1-hecb7ae0_102_cp313.conda
+  sha256: f0fb56c9b3eb9fb6c7f3264e1d14e4f332cfb6bd1b28f571eb10929fc099d7c5
+  md5: afcdcae1378a6d424ae3a7f763fa8efe
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-ppc64le >=2.36.1
+  - libexpat >=2.6.4,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - liblzma >=5.6.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.47.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.4.0,<4.0a0
+  - python_abi 3.13.* *_cp313
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  license: Python-2.0
+  purls: []
+  size: 34549062
+  timestamp: 1733433765851
+- kind: conda
   name: python-dateutil
   version: 2.9.0
   build: pyhd8ed1ab_0
@@ -2979,6 +5141,25 @@ packages:
   size: 222742
   timestamp: 1709299922152
 - kind: conda
+  name: python-dateutil
+  version: 2.9.0.post0
+  build: pyhff2d567_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
+  sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
+  md5: 5ba79d7c71f03c678c8ead841f347d6e
+  depends:
+  - python >=3.9
+  - six >=1.5
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/python-dateutil?source=hash-mapping
+  size: 222505
+  timestamp: 1733215763718
+- kind: conda
   name: python-dotenv
   version: 1.0.1
   build: pyhd8ed1ab_0
@@ -2995,6 +5176,24 @@ packages:
   - pkg:pypi/python-dotenv?source=hash-mapping
   size: 24278
   timestamp: 1706018281544
+- kind: conda
+  name: python-dotenv
+  version: 1.0.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_1.conda
+  sha256: 99713f6b534fef94995c6c16fd21d59f3548784e9111775d692bdc7c44678f02
+  md5: e5c6ed218664802d305e79cc2d4491de
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/python-dotenv?source=hash-mapping
+  size: 24215
+  timestamp: 1733243277223
 - kind: conda
   name: python-keystoneclient
   version: 4.2.0
@@ -3060,6 +5259,24 @@ packages:
   size: 144024
   timestamp: 1707747742930
 - kind: conda
+  name: python-tzdata
+  version: '2024.2'
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_1.conda
+  sha256: 57c9a02ec25926fb48edca59b9ede107823e5d5c473b94a0e05cc0b9a193a642
+  md5: c0def296b2f6d2dd7b030c2a7f66bb1f
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/tzdata?source=hash-mapping
+  size: 142235
+  timestamp: 1733235414217
+- kind: conda
   name: python_abi
   version: '3.12'
   build: 5_cp312
@@ -3092,6 +5309,38 @@ packages:
   size: 6329
   timestamp: 1723823366253
 - kind: conda
+  name: python_abi
+  version: '3.12'
+  build: 5_cp312
+  build_number: 5
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/python_abi-3.12-5_cp312.conda
+  sha256: 0ef1749696a0ecd321fbea231992599cff8bd7e266f0454793e678353457ed12
+  md5: bc1f7e514986f080afff56f293b9463f
+  constrains:
+  - python 3.12.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6281
+  timestamp: 1723823408697
+- kind: conda
+  name: python_abi
+  version: '3.13'
+  build: 5_cp313
+  build_number: 5
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/python_abi-3.13-5_cp313.conda
+  sha256: 9bdc0692cebad314f8a99be0e0211d7166f1c0f0ebfd71d3852dc8697e94549f
+  md5: 6c9e38648d79018980954c215a46d2e8
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6276
+  timestamp: 1723823492683
+- kind: conda
   name: pytz
   version: '2024.1'
   build: pyhd8ed1ab_0
@@ -3108,6 +5357,45 @@ packages:
   - pkg:pypi/pytz?source=hash-mapping
   size: 188538
   timestamp: 1706886944988
+- kind: conda
+  name: pytz
+  version: '2024.2'
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_1.conda
+  sha256: 0a7c706b2eb13f7da5692d9ddf1567209964875710b471de6f2743b33d1ba960
+  md5: f26ec986456c30f6dff154b670ae140f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytz?source=hash-mapping
+  size: 185890
+  timestamp: 1733215766006
+- kind: conda
+  name: pyyaml
+  version: 6.0.2
+  build: py312h2984477_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/pyyaml-6.0.2-py312h2984477_1.conda
+  sha256: 0c6f5fa46eeeb211ec89e2bd61442b2bf9943d6189088fbc9b9aeb2e6c41376d
+  md5: 0356d15a05c42179a7866ecf3b06e323
+  depends:
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 204562
+  timestamp: 1725456432203
 - kind: conda
   name: pyyaml
   version: 6.0.2
@@ -3148,6 +5436,44 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 205734
   timestamp: 1723018377857
+- kind: conda
+  name: pyyaml
+  version: 6.0.2
+  build: py313h7aac8da_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/pyyaml-6.0.2-py313h7aac8da_1.conda
+  sha256: 7810a88d4990a10772ed32991e049ba9b734c8bbfc3e952cccc91dc515742224
+  md5: 0dd2c19ca92a829dfe010334e4adc0cb
+  depends:
+  - libgcc >=13
+  - python >=3.13.0rc1,<3.14.0a0
+  - python >=3.13.0rc1,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 205033
+  timestamp: 1725456342209
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h0b9b154_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.2-h0b9b154_1.conda
+  sha256: 149754804bdd1dce9b0c868fca752dc2b9fbaba27aeb9be5a0cf89acd93dd898
+  md5: 7bb8e7bc9b64950865e875ceb29628fd
+  depends:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  purls: []
+  size: 304821
+  timestamp: 1679532435476
 - kind: conda
   name: readline
   version: '8.2'
@@ -3223,6 +5549,24 @@ packages:
   size: 34075
   timestamp: 1641825125307
 - kind: conda
+  name: rfc3986
+  version: 2.0.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
+  sha256: d617373ba1a5108336cb87754d030b9e384dcf91796d143fa60fe61e76e5cfb0
+  md5: 43e14f832d7551e5a8910672bfc3d8c6
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/rfc3986?source=hash-mapping
+  size: 38028
+  timestamp: 1733921806657
+- kind: conda
   name: rich
   version: 13.7.1
   build: pyhd8ed1ab_0
@@ -3242,6 +5586,48 @@ packages:
   - pkg:pypi/rich?source=hash-mapping
   size: 184347
   timestamp: 1709150578093
+- kind: conda
+  name: rich
+  version: 13.9.4
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/rich-13.9.4-pyhd8ed1ab_1.conda
+  sha256: 06a760c5ae572e72e865d5a87e9fe3cc171e1a9c996e63daf3db52ff1a0b4457
+  md5: 7aed65d4ff222bfb7335997aa40b7da5
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.9
+  - typing_extensions >=4.0.0,<5.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rich?source=hash-mapping
+  size: 185646
+  timestamp: 1733342347277
+- kind: conda
+  name: secretstorage
+  version: 3.3.3
+  build: py312h2344ed7_3
+  build_number: 3
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/secretstorage-3.3.3-py312h2344ed7_3.conda
+  sha256: 897f5ee4c4a1b8e4dbf84498e1eb827ba0091ac1e49c6bf1561b57e14c799ade
+  md5: 897cd77af9c66cfe9d095fa8b7323b0d
+  depends:
+  - cryptography
+  - dbus
+  - jeepney >=0.6
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/secretstorage?source=hash-mapping
+  size: 31323
+  timestamp: 1725916829994
 - kind: conda
   name: secretstorage
   version: 3.3.3
@@ -3302,6 +5688,24 @@ packages:
   size: 1459799
   timestamp: 1724163617860
 - kind: conda
+  name: setuptools
+  version: 75.6.0
+  build: pyhff2d567_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.6.0-pyhff2d567_1.conda
+  sha256: abb12e1dd515b13660aacb5d0fd43835bc2186cab472df25b7716cd65e095111
+  md5: fc80f7995e396cbaeabd23cf46c413dc
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=hash-mapping
+  size: 774252
+  timestamp: 1732632769210
+- kind: conda
   name: shellingham
   version: 1.5.4
   build: pyhd8ed1ab_0
@@ -3318,6 +5722,24 @@ packages:
   - pkg:pypi/shellingham?source=hash-mapping
   size: 14568
   timestamp: 1698144516278
+- kind: conda
+  name: shellingham
+  version: 1.5.4
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
+  sha256: 0557c090913aa63cdbe821dbdfa038a321b488e22bc80196c4b3b1aace4914ef
+  md5: 7c3c2a0f3ebdea2bbc35538d162b43bf
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/shellingham?source=hash-mapping
+  size: 14462
+  timestamp: 1733301007770
 - kind: conda
   name: six
   version: 1.16.0
@@ -3336,6 +5758,23 @@ packages:
   size: 14259
   timestamp: 1620240338595
 - kind: conda
+  name: six
+  version: 1.17.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
+  sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
+  md5: a451d576819089b0d672f18768be0f65
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/six?source=hash-mapping
+  size: 16385
+  timestamp: 1733381032766
+- kind: conda
   name: sniffio
   version: 1.3.1
   build: pyhd8ed1ab_0
@@ -3352,6 +5791,24 @@ packages:
   - pkg:pypi/sniffio?source=hash-mapping
   size: 15064
   timestamp: 1708953086199
+- kind: conda
+  name: sniffio
+  version: 1.3.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
+  sha256: c2248418c310bdd1719b186796ae50a8a77ce555228b6acd32768e2543a15012
+  md5: bf7a226e58dfb8346c70df36065d86c9
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/sniffio?source=hash-mapping
+  size: 15019
+  timestamp: 1733244175724
 - kind: conda
   name: stevedore
   version: 5.3.0
@@ -3371,6 +5828,25 @@ packages:
   size: 32094
   timestamp: 1724768423275
 - kind: conda
+  name: stevedore
+  version: 5.4.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/stevedore-5.4.0-pyhd8ed1ab_1.conda
+  sha256: 530b9ec38d99c296166602de05eb464cfeaf387e14a5c050915e9f300f6d70aa
+  md5: 3fdee981c212376754dc72e8e582aad4
+  depends:
+  - pbr !=2.1.0,>=2.0.0
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/stevedore?source=hash-mapping
+  size: 32102
+  timestamp: 1734338046530
+- kind: conda
   name: tk
   version: 8.6.13
   build: h194ca79_0
@@ -3386,6 +5862,22 @@ packages:
   purls: []
   size: 3351802
   timestamp: 1695506242997
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: hd4bbf49_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.13-hd4bbf49_0.conda
+  sha256: 4cfadfded379ad0aeeaee232bd0d7c32bfef238be3a2d17efc92512266b67246
+  md5: a26aaf28a5756f5b8fbff1a46962c649
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: TCL
+  license_family: BSD
+  purls: []
+  size: 3589612
+  timestamp: 1695506399933
 - kind: conda
   name: tk
   version: 8.6.13
@@ -3421,6 +5913,24 @@ packages:
   size: 15940
   timestamp: 1644342331069
 - kind: conda
+  name: tomli
+  version: 2.2.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
+  sha256: 18636339a79656962723077df9a56c0ac7b8a864329eb8f847ee3d38495b863e
+  md5: ac944244f1fed2eb49bae07193ae8215
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomli?source=hash-mapping
+  size: 19167
+  timestamp: 1733256819729
+- kind: conda
   name: tomli-w
   version: 1.0.0
   build: pyhd8ed1ab_0
@@ -3437,6 +5947,24 @@ packages:
   - pkg:pypi/tomli-w?source=hash-mapping
   size: 10052
   timestamp: 1638551820635
+- kind: conda
+  name: tomli-w
+  version: 1.1.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomli-w-1.1.0-pyhd8ed1ab_1.conda
+  sha256: ccc437aeade22da74754dba70320b2391314929eeb6ac9ecec254abcb2d7c673
+  md5: 663a601868ec1196889bce4f8493a55f
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomli-w?source=hash-mapping
+  size: 12358
+  timestamp: 1733216589780
 - kind: conda
   name: tomlkit
   version: 0.13.2
@@ -3455,6 +5983,24 @@ packages:
   size: 37279
   timestamp: 1723631592742
 - kind: conda
+  name: tomlkit
+  version: 0.13.2
+  build: pyha770c72_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.2-pyha770c72_1.conda
+  sha256: 986fae65f5568e95dbf858d08d77a0f9cca031345a98550f1d4b51d36d8811e2
+  md5: 1d9ab4fc875c52db83f9c9b40af4e2c8
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tomlkit?source=hash-mapping
+  size: 37372
+  timestamp: 1733230836889
+- kind: conda
   name: trove-classifiers
   version: 2024.7.2
   build: pyhd8ed1ab_0
@@ -3471,6 +6017,24 @@ packages:
   - pkg:pypi/trove-classifiers?source=hash-mapping
   size: 18302
   timestamp: 1719995164492
+- kind: conda
+  name: trove-classifiers
+  version: 2024.10.21.16
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.10.21.16-pyhd8ed1ab_1.conda
+  sha256: 46d7c55cd7953557fad895dfd924b98b588a844bbdd62782fcb4503b2eee29a5
+  md5: dfaeba73b8a87a63f238fae64447e7c6
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/trove-classifiers?source=hash-mapping
+  size: 18400
+  timestamp: 1733211924253
 - kind: conda
   name: typing_extensions
   version: 4.12.2
@@ -3489,6 +6053,24 @@ packages:
   size: 39888
   timestamp: 1717802653893
 - kind: conda
+  name: typing_extensions
+  version: 4.12.2
+  build: pyha770c72_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_1.conda
+  sha256: 337be7af5af8b2817f115b3b68870208b30c31d3439bec07bfb2d8f4823e3568
+  md5: d17f13df8b65464ca316cbc000a3cb64
+  depends:
+  - python >=3.9
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/typing-extensions?source=hash-mapping
+  size: 39637
+  timestamp: 1733188758212
+- kind: conda
   name: tzdata
   version: 2024a
   build: h8827d51_1
@@ -3502,6 +6084,19 @@ packages:
   purls: []
   size: 124164
   timestamp: 1724736371498
+- kind: conda
+  name: tzdata
+  version: 2024b
+  build: hc8b5060_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024b-hc8b5060_0.conda
+  sha256: 4fde5c3008bf5d2db82f2b50204464314cc3c91c1d953652f7bd01d9e52aefdf
+  md5: 8ac3367aafb1cc0a068483c580af8015
+  license: LicenseRef-Public-Domain
+  purls: []
+  size: 122354
+  timestamp: 1728047496079
 - kind: conda
   name: urllib3
   version: 2.2.2
@@ -3524,6 +6119,28 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 95048
   timestamp: 1719391384778
+- kind: conda
+  name: urllib3
+  version: 2.2.3
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_1.conda
+  sha256: 416e30a1c3262275f01a3e22e783118d9e9d2872a739a9ed860d06fa9c7593d5
+  md5: 4a2d8ef7c37b8808c5b9b750501fffce
+  depends:
+  - brotli-python >=1.0.9
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.9
+  - zstandard >=0.18.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/urllib3?source=hash-mapping
+  size: 98077
+  timestamp: 1733206968917
 - kind: conda
   name: userpath
   version: 1.7.0
@@ -3578,6 +6195,23 @@ packages:
   size: 7745325
   timestamp: 1724886316675
 - kind: conda
+  name: uv
+  version: 0.5.11
+  build: h3ec8af1_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/uv-0.5.11-h3ec8af1_0.conda
+  sha256: 5c5b20e3bc54e70ccc215bc0a0d3d29fabe2f28687d7035a71667c13c883627e
+  md5: 3ce1089779e6c6cac293ee4f46500143
+  depends:
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 OR MIT
+  purls: []
+  size: 10168262
+  timestamp: 1734704925323
+- kind: conda
   name: virtualenv
   version: 20.26.3
   build: pyhd8ed1ab_0
@@ -3598,6 +6232,26 @@ packages:
   size: 4363507
   timestamp: 1719150878323
 - kind: conda
+  name: virtualenv
+  version: 20.28.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.28.0-pyhd8ed1ab_0.conda
+  sha256: 82776f74e90a296b79415361faa6b10f360755c1fb8e6d59ca68509e6fe7e115
+  md5: 1d601bc1d28b5ce6d112b90f4b9b8ede
+  depends:
+  - distlib >=0.3.7,<1
+  - filelock >=3.12.2,<4
+  - platformdirs >=3.9.1,<5
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/virtualenv?source=hash-mapping
+  size: 3350255
+  timestamp: 1732609542072
+- kind: conda
   name: werkzeug
   version: 3.0.4
   build: pyhd8ed1ab_0
@@ -3616,6 +6270,25 @@ packages:
   size: 242269
   timestamp: 1724330851536
 - kind: conda
+  name: werkzeug
+  version: 3.1.3
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.3-pyhd8ed1ab_1.conda
+  sha256: cd9a603beae0b237be7d9dfae8ae0b36ad62666ac4bb073969bce7da6f55157c
+  md5: 0a9b57c159d56b508613cc39022c1b9e
+  depends:
+  - markupsafe >=2.1.1
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/werkzeug?source=hash-mapping
+  size: 243546
+  timestamp: 1733160561258
+- kind: conda
   name: wheel
   version: 0.44.0
   build: pyhd8ed1ab_0
@@ -3632,6 +6305,24 @@ packages:
   - pkg:pypi/wheel?source=hash-mapping
   size: 58585
   timestamp: 1722797131787
+- kind: conda
+  name: wheel
+  version: 0.45.1
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
+  sha256: 1b34021e815ff89a4d902d879c3bd2040bc1bd6169b32e9427497fa05c55f1ce
+  md5: 75cb7132eb58d97896e173ef12ac9986
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/wheel?source=hash-mapping
+  size: 62931
+  timestamp: 1733130309598
 - kind: conda
   name: wrapt
   version: 1.16.0
@@ -3670,6 +6361,44 @@ packages:
   size: 63110
   timestamp: 1699533012760
 - kind: conda
+  name: wrapt
+  version: 1.17.0
+  build: py312h2984477_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/wrapt-1.17.0-py312h2984477_0.conda
+  sha256: ca0c268d9e9905e1ee3822a9d49ba4b6165937e0bea2069130a77c0416383dc8
+  md5: d065a3b7a16b6b90c01e29cda58e6edd
+  depends:
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 65128
+  timestamp: 1732523782461
+- kind: conda
+  name: wrapt
+  version: 1.17.0
+  build: py313h7aac8da_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/wrapt-1.17.0-py313h7aac8da_0.conda
+  sha256: c1a8c4abde132d3bdd3ba913096009aee27d4c529fa44029f2f313938a612561
+  md5: 58cc1a6be1f4911aa537fa762012f896
+  depends:
+  - libgcc >=13
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/wrapt?source=hash-mapping
+  size: 65788
+  timestamp: 1732523778045
+- kind: conda
   name: xz
   version: 5.2.6
   build: h166bdaf_0
@@ -3697,6 +6426,22 @@ packages:
   purls: []
   size: 440555
   timestamp: 1660348056328
+- kind: conda
+  name: yaml
+  version: 0.2.5
+  build: h4e0d66e_2
+  build_number: 2
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/yaml-0.2.5-h4e0d66e_2.tar.bz2
+  sha256: 1fdf204ef2126b10b1e783e862c49a1fdadfb440c7c51cd49df792000450b1d1
+  md5: e480df649632a5f96b7a24dfc213fd3d
+  depends:
+  - libgcc-ng >=9.4.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 109261
+  timestamp: 1641348050084
 - kind: conda
   name: yaml
   version: 0.2.5
@@ -3747,6 +6492,24 @@ packages:
   size: 21110
   timestamp: 1724731063145
 - kind: conda
+  name: zipp
+  version: 3.21.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
+  sha256: 567c04f124525c97a096b65769834b7acb047db24b15a56888a322bf3966c3e1
+  md5: 0c3cc595284c5e8f0f9900a9b228a332
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/zipp?source=hash-mapping
+  size: 21809
+  timestamp: 1732827613585
+- kind: conda
   name: zstandard
   version: 0.23.0
   build: py312h3483029_0
@@ -3771,6 +6534,28 @@ packages:
 - kind: conda
   name: zstandard
   version: 0.23.0
+  build: py312h3e12cc9_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstandard-0.23.0-py312h3e12cc9_1.conda
+  sha256: 7c698b4ea979cb215abb8a508a6739b2cc1d23accec985f58f853bc52dd48ae1
+  md5: 87de3e0a4fbbf4f2a029a77b1bb4f822
+  depends:
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
+  size: 443899
+  timestamp: 1725306717979
+- kind: conda
+  name: zstandard
+  version: 0.23.0
   build: py312h9fc3309_0
   subdir: linux-aarch64
   url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstandard-0.23.0-py312h9fc3309_0.conda
@@ -3791,6 +6576,28 @@ packages:
   size: 392329
   timestamp: 1721044339954
 - kind: conda
+  name: zstandard
+  version: 0.23.0
+  build: py313h75d07f5_1
+  build_number: 1
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstandard-0.23.0-py313h75d07f5_1.conda
+  sha256: bc42fc93b5fcdb8da82241195990c2132c5c7455b658ccbed6a76da8772ed63b
+  md5: c516f02699b010bf97f1bf15fad68a8e
+  depends:
+  - cffi >=1.11
+  - libgcc >=13
+  - python >=3.13.0rc1,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - zstd >=1.5.6,<1.5.7.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/zstandard?source=hash-mapping
+  size: 451328
+  timestamp: 1725306759899
+- kind: conda
   name: zstd
   version: 1.5.6
   build: h02f22dd_0
@@ -3807,6 +6614,23 @@ packages:
   purls: []
   size: 539937
   timestamp: 1714723130243
+- kind: conda
+  name: zstd
+  version: 1.5.6
+  build: h03a2076_0
+  subdir: linux-ppc64le
+  url: https://conda.anaconda.org/conda-forge/linux-ppc64le/zstd-1.5.6-h03a2076_0.conda
+  sha256: 99f0283ffce0ac200da98d63a9b2d86dc31a59aef2f1ca7540b3d3107bfb55d9
+  md5: a9d68e57375d156a0fb5fde2ad0cf2a6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 608620
+  timestamp: 1714723066884
 - kind: conda
   name: zstd
   version: 1.5.6

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,0 +1,13 @@
+# Dockerfile for multi-arch "production" images.
+# Before building this image, the conda environment and pfcon wheel must be built on-the-metal.
+
+FROM docker.io/library/debian:bookworm-slim
+
+ARG TARGETPLATFORM
+COPY ./envs/${TARGETPLATFORM} /opt/conda-env
+ENV PATH=/opt/conda-env/bin:$PATH
+
+RUN --mount=type=bind,source=./dist,target=/dist pip install --no-deps --no-cache-dir /dist/pfcon-*.whl
+
+CMD ["gunicorn", "--bind", "0.0.0.0:5005", "--workers", "8", "--timeout", "3600", "pfcon.wsgi:application"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = ["hatchling"]
 
 [tool.pixi.project]
 channels = ["conda-forge"]
-platforms = ["linux-64", "linux-aarch64"]
+platforms = ["linux-64", "linux-aarch64", "linux-ppc64le"]
 
 [tool.pixi.pypi-dependencies]
 pfcon = { path = ".", editable = true }


### PR DESCRIPTION
`pixi` (neither `micromamba` nor `uv`) provide container images for `linux/ppc64le`. In this PR, a solution for building for `ppc64le` is added:

1. Run `pixi project export ...` to produce a conda spec
2. Run `micromamba create ...` to produce conda environments for the target platforms
3. Run `pixi run build` (which calls `hatch`) to produce a wheel for `pfcon`
4. Copy the conda environment and `pfcon-*.whl` into images and build

There is also an added benefit: by running the package manager on the host instead of in docker build, it is faster (compared to running the package manager during `docker build` using QEMU).