### PR TITLE
Fix input mount and label issues for kubernetes

### DIFF
--- a/kubernetes/pfcon_dev_innetwork.yaml
+++ b/kubernetes/pfcon_dev_innetwork.yaml
@@ -212,5 +212,4 @@ spec:
               mountPath: "/srv"
       volumes:
         - name: swiftdb
-          hostPath:
-            path: ${SOURCEDIR}/swift_storage
+          emptyDir: {}

--- a/kubernetes/pfcon_dev_innetwork_fs.yaml
+++ b/kubernetes/pfcon_dev_innetwork_fs.yaml
@@ -1,4 +1,72 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pfcon
+  labels:
+    app: pfcon
+    env: development
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pfcon
+  labels:
+    app: pfcon
+    env: development
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["get"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pfcon
+  labels:
+    app: pfcon
+    env: development
+subjects:
+  - kind: ServiceAccount
+    name: pfcon
+    namespace: default
+roleRef:
+  kind: Role
+  name: pfcon
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storebase-pvc
+  labels:
+    app: pfcon
+    env: development
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: hostpath
+  resources:
+    requests:
+      storage: 2Gi
+
+---
+
+apiVersion: v1
 kind: Service
 metadata:
   name: pfcon
@@ -37,6 +105,7 @@ spec:
         app: pfcon
         env: development
     spec:
+      serviceAccountName: pfcon
       containers:
         - image: localhost:5000/fnndsc/pfcon:dev
           name: pfcon
@@ -48,17 +117,21 @@ spec:
             - name: APPLICATION_MODE
               value: development
             - name: PFCON_INNETWORK
-              value: true
+              value: "true"
             - name: STORAGE_ENV
               value: ${STORAGE_ENV}
             - name: COMPUTE_VOLUME_TYPE
-            - value: ${COMPUTE_VOLUME_TYPE}
-            - name: STOREBASE
-              value: ${STOREBASE}
+              value: kubernetes_pvc
+            - name: VOLUME_NAME
+              value: storebase-pvc
+            - name: STOREBASE_MOUNT
+              value: /var/local/storeBase
             - name: CONTAINER_ENV
               value: kubernetes
-          command: ["python"]
-          args: ["-m", "pfcon"]
+            - name: PFCON_OP_IMAGE
+              value: ghcr.io/fnndsc/pfconopjob
+          command: ["pixi"]
+          args: ["run", "python", "-m", "pfcon"]
           volumeMounts:
             - mountPath: "/var/local/storeBase"
               name: "storebase"
@@ -68,8 +141,8 @@ spec:
               name: "pfcon-tests"
       volumes:
         - name: "storebase"
-          hostPath:
-            path: ${STOREBASE}
+          persistentVolumeClaim:
+            claimName: storebase-pvc
         - name: "pfcon-source"
           hostPath:
             path: ${SOURCEDIR}/pfcon

--- a/kubernetes/pfcon_dev_innetwork_s3.yaml
+++ b/kubernetes/pfcon_dev_innetwork_s3.yaml
@@ -219,5 +219,4 @@ spec:
               mountPath: "/data"
       volumes:
         - name: s3db
-          hostPath:
-            path: ${SOURCEDIR}/s3_storage
+          emptyDir: {}

--- a/kubernetes/pfcon_dev_innetwork_s3.yaml
+++ b/kubernetes/pfcon_dev_innetwork_s3.yaml
@@ -107,9 +107,9 @@ spec:
     spec:
       serviceAccountName: pfcon
       initContainers:
-        - name: init-swift
+        - name: init-s3
           image: busybox:1.32
-          command: ["sh", "-c", "until wget --spider -S -T 2 http://swift:8080/info 2>&1 | grep '200 OK'; do echo waiting for Swift storage; sleep 2; done"]
+          command: ["sh", "-c", "until wget --spider -S -T 2 http://s3-service:9000/minio/health/live 2>&1 | grep '200 OK'; do echo waiting for S3 storage; sleep 2; done"]
       containers:
         - image: localhost:5000/fnndsc/pfcon:dev
           name: pfcon
@@ -123,7 +123,7 @@ spec:
             - name: PFCON_INNETWORK
               value: "true"
             - name: STORAGE_ENV
-              value: swift
+              value: s3
             - name: COMPUTE_VOLUME_TYPE
               value: kubernetes_pvc
             - name: VOLUME_NAME
@@ -133,9 +133,9 @@ spec:
             - name: CONTAINER_ENV
               value: kubernetes
             - name: PFCON_OP_IMAGE
-              value: ghcr.io/fnndsc/pfconopjob-swift
-            - name: SWIFT_AUTH_URL
-              value: http://swift:8080/auth/v1.0
+              value: ghcr.io/fnndsc/pfconopjob-s3
+            - name: S3_ENDPOINT_URL
+              value: http://s3-service:9000
           command: ["pixi"]
           args: ["run", "python", "-m", "pfcon"]
           volumeMounts:
@@ -161,56 +161,63 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: swift
+  name: s3-service
   labels:
-    app: swift
+    app: s3
     env: production
 spec:
   type: NodePort
   selector:
-    app: swift
+    app: s3
     env: production
   ports:
-    - port: 8080
-      targetPort: 8080
-      nodePort: 30080
+    - name: api
+      port: 9000
+      targetPort: 9000
+      nodePort: 30090
+    - name: console
+      port: 9001
+      targetPort: 9001
+      nodePort: 30091
 
 ---
 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: swift
+  name: s3
   labels:
-    app: swift
+    app: s3
     env: production
 spec:
   replicas: 1  # stateful service, so only a single replica must be used
   selector:
     matchLabels:
-      app: swift
+      app: s3
       env: production
   template:
     metadata:
-      name: swift
+      name: s3
       labels:
-        app: swift
+        app: s3
         env: production
     spec:
       containers:
-        - name: swift
-          image: fnndsc/docker-swift-onlyone
+        - name: s3
+          image: docker.io/minio/minio:latest
+          args: ["server", "/data", "--console-address", ":9001"]
           ports:
-            - containerPort: 8080
+            - containerPort: 9000
+            - containerPort: 9001
           env:
-            - name: SWIFT_USERNAME
-              value: chris:chris1234
-            - name: SWIFT_KEY
-              value: testing
+            - name: MINIO_ROOT_USER
+              value: minioadmin
+            - name: MINIO_ROOT_PASSWORD
+              value: minioadmin
           volumeMounts:
-            - name: swiftdb
-              mountPath: "/srv"
+            - name: s3db
+              mountPath: "/data"
       volumes:
-        - name: swiftdb
+        - name: s3db
           hostPath:
-            path: ${SOURCEDIR}/swift_storage
+            path: ${SOURCEDIR}/s3_storage

--- a/make.sh
+++ b/make.sh
@@ -316,8 +316,16 @@ title -d 1 "Starting pfcon containerized dev environment on $CONTAINER_ENV"
         fi
     elif [[ $CONTAINER_ENV == kubernetes ]]; then
         if (( b_pfconInNetwork )) ; then
-            echo "envsubst < kubernetes/pfcon_dev_innetwork.yaml | kubectl apply -f -" | ./boxes.sh ${LightCyan}
-            envsubst < kubernetes/pfcon_dev_innetwork.yaml | kubectl apply -f -
+            if [[ $STORAGE_ENV == 'swift' ]]; then
+                echo "envsubst < kubernetes/pfcon_dev_innetwork.yaml | kubectl apply -f -" | ./boxes.sh ${LightCyan}
+                envsubst < kubernetes/pfcon_dev_innetwork.yaml | kubectl apply -f -
+            elif [[ $STORAGE_ENV == 's3' ]]; then
+                echo "envsubst < kubernetes/pfcon_dev_innetwork_s3.yaml | kubectl apply -f -" | ./boxes.sh ${LightCyan}
+                envsubst < kubernetes/pfcon_dev_innetwork_s3.yaml | kubectl apply -f -
+            elif [[ $STORAGE_ENV == 'fslink' ]]; then
+                echo "envsubst < kubernetes/pfcon_dev_innetwork_fs.yaml | kubectl apply -f -" | ./boxes.sh ${LightCyan}
+                envsubst < kubernetes/pfcon_dev_innetwork_fs.yaml | kubectl apply -f -
+            fi
         else
             echo "envsubst < kubernetes/pfcon_dev.yaml | kubectl apply -f -"           | ./boxes.sh ${LightCyan}
             envsubst < kubernetes/pfcon_dev.yaml | kubectl apply -f -

--- a/pfcon/base_resources.py
+++ b/pfcon/base_resources.py
@@ -89,7 +89,7 @@ class BaseJobList(Resource):
         storebase root).
         """
         mounts_dict = {
-            'inputdir_source': '',
+            'inputdir_source': None,
             'inputdir_target': self.str_app_container_inputdir,
             'outputdir_source': '',
             'outputdir_target': self.str_app_container_outputdir,
@@ -162,7 +162,7 @@ class BaseJobList(Resource):
 
         extra_labels = {}
         if job_type:
-            extra_labels['org.chrisproject.job_type'] = job_type
+            extra_labels['job_type'] = job_type
 
         compute_mgr = get_compute_mgr(self.container_env)
         try:

--- a/pfcon/compute/abstractmgr.py
+++ b/pfcon/compute/abstractmgr.py
@@ -73,9 +73,14 @@ class ResourcesDict(TypedDict):
 
 
 class MountsDict(TypedDict):
-    inputdir_source: str
+    inputdir_source: Optional[str]
     """
-    Absolute path to the source input directory or otherwise a volume name.
+    Source input directory for the input mount.
+
+    - ``None``: no input mount.
+    - ``''`` (empty string): mount the whole volume root (Kubernetes PVC);
+      not valid for host/volume-based Docker bind mounts.
+    - non-empty string: absolute path (host/docker) or sub-path (k8s PVC).
     """
     inputdir_target: str
     """
@@ -98,10 +103,26 @@ class AbstractManager(ABC, Generic[J]):
     information about previously scheduled plugin instances.
     """
 
+    # Map from semantic label name (as emitted by pfcon resources) to the
+    # concrete label key used on this backend. Subclasses override with the
+    # key format idiomatic to their engine (reverse-DNS for Docker,
+    # prefix/name for Kubernetes).
+    LABEL_KEYS: dict = {}
+
     def __init__(self, config_dict: dict = None):
         super().__init__()
 
         self.config = config_dict
+
+    def translate_labels(self, labels: Optional[dict]) -> dict:
+        """
+        Translate a dict of semantic labels (e.g. ``{'job_type': 'plugin'}``)
+        into the concrete label keys for this backend. Unknown keys are
+        passed through unchanged.
+        """
+        if not labels:
+            return {}
+        return {self.LABEL_KEYS.get(k, k): v for k, v in labels.items()}
 
     @abstractmethod
     def schedule_job(self, image: Image, command: List[str], name: JobName,

--- a/pfcon/compute/dockermgr.py
+++ b/pfcon/compute/dockermgr.py
@@ -15,6 +15,9 @@ class DockerManager(AbstractManager[Container]):
     """
     Interface between pfcon and Docker Engine or Podman API.
     """
+
+    LABEL_KEYS = {'job_type': 'org.chrisproject.job_type'}
+
     def __init__(self, config_dict=None, docker_client: DockerClient = None):
         super().__init__(config_dict)
 
@@ -44,7 +47,7 @@ class DockerManager(AbstractManager[Container]):
             mounts_dict['outputdir_source']: {'bind': mounts_dict['outputdir_target'],
                                               'mode': 'rw'},
         }
-        if mounts_dict['inputdir_source']:
+        if mounts_dict['inputdir_source']:  # None or '' => no input mount
             vol[mounts_dict['inputdir_source']] = {
                 'bind': mounts_dict['inputdir_target'], 'mode': 'ro'}
         volumes = {'volumes': vol}
@@ -69,7 +72,7 @@ class DockerManager(AbstractManager[Container]):
         if (s := self.config.get('SHM_SIZE')) is not None:
             shm_size['shm_size'] = s.as_mb()
 
-        labels = {**self.job_labels, **(extra_labels or {})}
+        labels = {**self.job_labels, **self.translate_labels(extra_labels)}
 
         return self.__docker.containers.run(
             image=image,

--- a/pfcon/compute/kubernetesmgr.py
+++ b/pfcon/compute/kubernetesmgr.py
@@ -26,6 +26,8 @@ def str_to_v1_local_object_reference(image_pull_secret: str):
 
 class KubernetesManager(AbstractManager[V1Job]):
 
+    LABEL_KEYS = {'job_type': 'chrisproject.org/job-type'}
+
     def __init__(self, config_dict=None):
         super().__init__(config_dict)
 
@@ -194,11 +196,13 @@ class KubernetesManager(AbstractManager[V1Job]):
         )
 
         volume_mount_inputdir = None
-        if mounts_dict['inputdir_source']:
+        if mounts_dict['inputdir_source'] is not None:
+            # empty string sub_path => mount the whole PVC root
+            sub_path = mounts_dict['inputdir_source'] or None
             volume_mount_inputdir = k_client.V1VolumeMount(
                 mount_path=mounts_dict['inputdir_target'],
                 name='storebase',
-                sub_path=mounts_dict['inputdir_source'],
+                sub_path=sub_path,
                 read_only=True
             )
 
@@ -230,8 +234,7 @@ class KubernetesManager(AbstractManager[V1Job]):
 
         pod_template_metadata = None
         labels_config = dict(self.config.get('JOB_LABELS') or {})
-        if extra_labels:
-            labels_config.update(extra_labels)
+        labels_config.update(self.translate_labels(extra_labels))
         if labels_config:
             pod_template_metadata = k_client.V1ObjectMeta(labels=labels_config)
 

--- a/pfcon/compute/swarmmgr.py
+++ b/pfcon/compute/swarmmgr.py
@@ -13,6 +13,8 @@ from .abstractmgr import (AbstractManager, ManagerException, JobStatus, JobInfo,
 
 class SwarmManager(AbstractManager[Service]):
 
+    LABEL_KEYS = {'job_type': 'org.chrisproject.job_type'}
+
     def __init__(self, config_dict=None):
         super().__init__(config_dict)
 

--- a/pfcon/resources.py
+++ b/pfcon/resources.py
@@ -230,7 +230,7 @@ class CopyJobList(BaseJobList):
             mounts_dict = self._build_key_mounts(job_id, inputdir_override)
         else:
             mounts_dict = self._build_key_mounts(job_id)
-            mounts_dict['inputdir_source'] = ''  # swift/s3 copy reads from network
+            mounts_dict['inputdir_source'] = None  # swift/s3 copy reads from network
 
         copy_env = []
         if self.storage_env == 'swift':
@@ -381,7 +381,7 @@ class PluginJobList(BaseJobList):
             'gpu_limit': args.gpu_limit,
         }
         mounts_dict = {
-            'inputdir_source': '',
+            'inputdir_source': None,
             'inputdir_target': self.str_app_container_inputdir,
             'outputdir_source': '',
             'outputdir_target': self.str_app_container_outputdir,
@@ -606,7 +606,7 @@ class UploadJobList(BaseJobList):
         }
 
         mounts_dict = self._build_key_mounts(job_id)
-        mounts_dict['inputdir_source'] = ''  # upload worker needs no input mount
+        mounts_dict['inputdir_source'] = None  # upload worker needs no input mount
         if self.storage_env == 'swift':
             upload_env = self._build_swift_env()
         else:
@@ -717,7 +717,7 @@ class DeleteJobList(BaseJobList):
         }
 
         mounts_dict = self._build_key_mounts(job_id)
-        mounts_dict['inputdir_source'] = ''  # delete worker needs no input mount
+        mounts_dict['inputdir_source'] = None  # delete worker needs no input mount
 
         _, d_compute = self._schedule_container(
             op_image, delete_cmd, delete_name, resources_dict, [],

--- a/tests/compute/conftest.py
+++ b/tests/compute/conftest.py
@@ -7,7 +7,12 @@ from docker import DockerClient
 
 @pytest.fixture(scope='session')
 def docker_client() -> DockerClient:
-    return docker.from_env()
+    try:
+        client = docker.from_env()
+        client.ping()
+    except Exception as e:
+        pytest.skip(f'Docker not available: {e}')
+    return client
 
 
 @pytest.fixture(scope='session')

--- a/tests/compute/test_kubernetesmgr.py
+++ b/tests/compute/test_kubernetesmgr.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for KubernetesManager.create_job focused on volume mount
+construction and label formatting. These cover regressions around
+issue FNNDSC/pfcon#162 (sub_path missing for copy/delete jobs) and
+the k8s-idiomatic label key `chrisproject.org/job-type`.
+
+These tests do not require a live cluster: kubernetes.config loading
+is mocked and only the in-memory V1Job is built via create_job.
+"""
+import unittest
+from unittest import mock
+
+
+class TestKubernetesManagerCreateJob(unittest.TestCase):
+
+    def _make_manager(self, config=None):
+        from pfcon.compute.kubernetesmgr import KubernetesManager
+
+        cfg = {'VOLUME_NAME': 'storebase-pvc'}
+        if config:
+            cfg.update(config)
+
+        with mock.patch(
+                'pfcon.compute.kubernetesmgr.k_config.load_incluster_config'), \
+             mock.patch(
+                'pfcon.compute.kubernetesmgr.k_client.CoreV1Api'), \
+             mock.patch(
+                'pfcon.compute.kubernetesmgr.k_client.BatchV1Api'):
+            return KubernetesManager(cfg)
+
+    def _resources(self):
+        return {
+            'number_of_workers': 1,
+            'cpu_limit': 1000,
+            'memory_limit': 300,
+            'gpu_limit': 0,
+        }
+
+    def _get_vol_mounts(self, job):
+        return job.spec.template.spec.containers[0].volume_mounts
+
+    def test_output_mount_has_sub_path(self):
+        """Regression for #162: outputdir_source must translate to
+        V1VolumeMount.sub_path so copy/delete workers see job files."""
+        mgr = self._make_manager()
+        mounts = {
+            'inputdir_source': None,
+            'inputdir_target': '/share/incoming',
+            'outputdir_source': 'key-jid-1',
+            'outputdir_target': '/share/outgoing',
+        }
+        job = mgr.create_job(
+            'img', ['python'], 'jid-1-delete', self._resources(),
+            [], None, None, mounts
+        )
+
+        vms = self._get_vol_mounts(job)
+        outmount = next(vm for vm in vms if vm.mount_path == '/share/outgoing')
+        self.assertEqual(outmount.sub_path, 'key-jid-1')
+        self.assertEqual(outmount.name, 'storebase')
+
+    def test_inputdir_none_means_no_mount(self):
+        """inputdir_source=None => no input volume mount."""
+        mgr = self._make_manager()
+        mounts = {
+            'inputdir_source': None,
+            'inputdir_target': '/share/incoming',
+            'outputdir_source': 'key-jid-2',
+            'outputdir_target': '/share/outgoing',
+        }
+        job = mgr.create_job(
+            'img', ['python'], 'jid-2-upload', self._resources(),
+            [], None, None, mounts
+        )
+
+        vms = self._get_vol_mounts(job)
+        self.assertFalse(
+            any(vm.mount_path == '/share/incoming' for vm in vms)
+        )
+
+    def test_inputdir_empty_string_mounts_volume_root(self):
+        """Regression: fslink copy passes inputdir_source='' meaning
+        mount whole PVC root. The input mount must be present with no
+        sub_path (sub_path=None)."""
+        mgr = self._make_manager()
+        mounts = {
+            'inputdir_source': '',
+            'inputdir_target': '/share/incoming',
+            'outputdir_source': 'key-jid-3',
+            'outputdir_target': '/share/outgoing',
+        }
+        job = mgr.create_job(
+            'img', ['python'], 'jid-3-copy', self._resources(),
+            [], None, None, mounts
+        )
+
+        vms = self._get_vol_mounts(job)
+        inmount = next(
+            (vm for vm in vms if vm.mount_path == '/share/incoming'), None
+        )
+        self.assertIsNotNone(inmount, 'input mount must be present')
+        self.assertIsNone(inmount.sub_path, 'must mount PVC root, no sub_path')
+        self.assertEqual(inmount.name, 'storebase')
+
+    def test_inputdir_subpath(self):
+        """Non-empty inputdir_source => sub_path on the input mount."""
+        mgr = self._make_manager()
+        mounts = {
+            'inputdir_source': 'key-jid-4/incoming',
+            'inputdir_target': '/share/incoming',
+            'outputdir_source': 'key-jid-4',
+            'outputdir_target': '/share/outgoing',
+        }
+        job = mgr.create_job(
+            'img', ['python'], 'jid-4', self._resources(),
+            [], None, None, mounts
+        )
+
+        vms = self._get_vol_mounts(job)
+        inmount = next(vm for vm in vms if vm.mount_path == '/share/incoming')
+        self.assertEqual(inmount.sub_path, 'key-jid-4/incoming')
+
+    def test_job_type_label_uses_k8s_convention(self):
+        """Kubernetes label key must be `chrisproject.org/job-type`,
+        not the docker-style `org.chrisproject.job_type`."""
+        mgr = self._make_manager()
+        mounts = {
+            'inputdir_source': None,
+            'inputdir_target': '/share/incoming',
+            'outputdir_source': 'key-jid-5',
+            'outputdir_target': '/share/outgoing',
+        }
+        job = mgr.create_job(
+            'img', ['python'], 'jid-5-copy', self._resources(),
+            [], None, None, mounts,
+            extra_labels={'job_type': 'copy'}
+        )
+        labels = job.spec.template.metadata.labels
+        self.assertIn('chrisproject.org/job-type', labels)
+        self.assertEqual(labels['chrisproject.org/job-type'], 'copy')
+        self.assertNotIn('org.chrisproject.job_type', labels)
+        self.assertNotIn('job_type', labels)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_resources_mocked.py
+++ b/tests/test_resources_mocked.py
@@ -50,6 +50,7 @@ class NewResourcesTestBase(TestCase):
 
         env_patch = {
             'APPLICATION_MODE': 'dev',
+            'CONTAINER_ENV': 'docker',
             'COMPUTE_VOLUME_TYPE': 'host',
             'STOREBASE': self.tmpdir,
             'STOREBASE_MOUNT': self.tmpdir,
@@ -135,7 +136,7 @@ class TestCopyJobList(NewResourcesTestBase):
 
         # fslink copy needs input mount (storebase root)
         mounts = mgr.schedule_job.call_args[0][7]
-        self.assertNotEqual(mounts['inputdir_source'], '')
+        self.assertIsNotNone(mounts['inputdir_source'])
 
     def test_post_idempotent_existing_copy(self):
         """If copy container already exists and is running, return
@@ -795,7 +796,7 @@ class TestUploadJobList(NewResourcesTestBase):
 
             # upload worker needs no input mount
             mounts = mgr.schedule_job.call_args[0][7]
-            self.assertEqual(mounts['inputdir_source'], '')
+            self.assertIsNone(mounts['inputdir_source'])
 
             # upload_params.json should exist
             params_file = os.path.join(key_dir, 'upload_params.json')
@@ -984,7 +985,7 @@ class TestDeleteJobList(NewResourcesTestBase):
 
         # delete worker needs no input mount
         mounts = mgr.schedule_job.call_args[0][7]
-        self.assertEqual(mounts['inputdir_source'], '')
+        self.assertIsNone(mounts['inputdir_source'])
 
     def test_post_noop_when_no_key_dir(self):
         """If the key directory doesn't exist, return success immediately."""

--- a/tests/test_resources_swift.py
+++ b/tests/test_resources_swift.py
@@ -45,7 +45,8 @@ class NewResourcesSwiftTests(TestCase):
             'SWIFT_CONNECTION_PARAMS': {
                 'user': 'chris:chris1234',
                 'key': 'testing',
-                'authurl': 'http://swift_service:8080/auth/v1.0',
+                'authurl': os.environ.get(
+                    'SWIFT_AUTH_URL', 'http://swift_service:8080/auth/v1.0'),
             },
         })
         self.client = self.app.test_client()


### PR DESCRIPTION
- Use the k8s-idiomatic label key `chrisproject.org/job-type` on Kubernetes; keep `org.chrisproject.job_type` on Docker/Swarm.
- Fix issue #162 (`fslink` copy input mount missing on k8s).


